### PR TITLE
Add dependabot endpoint

### DIFF
--- a/endpoints/dependabot.ts
+++ b/endpoints/dependabot.ts
@@ -9,20 +9,20 @@ import {
 export const meta: Meta = {
   title: 'Dependabot',
   examples: {
-    '/dependabot/github/dependabot/dependabot-core/?icon=dependabot': 'status',
-    '/dependabot/github/greenkeeperio/greenkeeper/<repo_id>?icon=dependabot': 'status (private repo)'
+    '/dependabot/dependabot/dependabot-core/?icon=dependabot': 'status',
+    '/dependabot/greenkeeperio/greenkeeper/<repo_id>?icon=dependabot': 'status (private repo)'
   }
 }
 
 export const handlers: Handlers = {
-  '/dependabot/:host<github|gitlab>/:owner/:repo/:identifier?': handler
+  '/dependabot/:owner/:repo/:identifier?': handler
 }
 
 export default badgenServe(handlers)
 
-async function handler ({ host, owner, repo, identifier }: Args) {
+async function handler ({ owner, repo, identifier }: Args) {
   // https://github.com/dependabot/feedback/issues/6#issuecomment-503994253
-  let endpoint = `https://api.dependabot.com/badges/status?host=${host}&repo=${owner}/${repo}`
+  let endpoint = `https://api.dependabot.com/badges/status?host=github&repo=${owner}/${repo}`
   if (!!identifier && identifier !== '<repo_id>') {
     endpoint += `&identifier=${identifier}`
   }

--- a/endpoints/dependabot.ts
+++ b/endpoints/dependabot.ts
@@ -1,0 +1,36 @@
+import got from '../libs/got'
+import {
+  badgenServe,
+  BadgenServeMeta as Meta,
+  BadgenServeHandlers as Handlers,
+  BadgenServeHandlerArgs as Args
+} from '../libs/badgen-serve'
+
+export const meta: Meta = {
+  title: 'Dependabot',
+  examples: {
+    '/dependabot/github/dependabot/dependabot-core/?icon=dependabot': 'status',
+    '/dependabot/github/greenkeeperio/greenkeeper/<repo_id>?icon=dependabot': 'status (private repo)'
+  }
+}
+
+export const handlers: Handlers = {
+  '/dependabot/:host<github|gitlab>/:owner/:repo/:identifier?': handler
+}
+
+export default badgenServe(handlers)
+
+async function handler ({ host, owner, repo, identifier }: Args) {
+  // https://github.com/dependabot/feedback/issues/6#issuecomment-503994253
+  let endpoint = `https://api.dependabot.com/badges/status?host=${host}&repo=${owner}/${repo}`
+  if (!!identifier && identifier !== '<repo_id>') {
+    endpoint += `&identifier=${identifier}`
+  }
+  const { status, colour } = await got(endpoint).then(res => res.body);
+
+  return {
+    subject: 'Dependabot',
+    status,
+    color: colour
+  }
+}

--- a/endpoints/dependabot.ts
+++ b/endpoints/dependabot.ts
@@ -6,12 +6,44 @@ import {
   BadgenServeHandlerArgs as Args
 } from '../libs/badgen-serve'
 
+const help = `
+## Private repositories
+In order to use the dependabot badge with a private GitHub repository you will need to get its id. You can use the [GitHub API](https://developer.github.com/v3/) and [curl](https://curl.haxx.se/docs/manual.html) to do this like so:
+<pre>
+curl -u "<b>$your_username</b>" https://api.github.com/repos/<b>$repo_owner</b>/<b>$repo_name</b>
+</pre>
+* _\`$your_username\` is well your GitHub username for authentication._
+* _\`$repo_owner\` is the owner of the repo e.g. badgen._
+* _\`$repo_name\` is the name of the repo e.g. badgen-icons._
+
+You will need to have read permissions for the repo for this to work, and once entering the command you will be prompted to provide a password for your GitHub account. If you use 2 factor authentication use one of the following 2 methods:
+
+* Pass a 2 factor authentication code
+  <pre>
+  curl -u "$your_username" <b>--header 'x-github-otp: $2fa_code'</b> https://api.github.com/repos/$repo_owner/$repo_name
+  </pre>
+  * _\`$2fa_code\` is the 2 factor authentication code from your phone._
+
+* Pass a personal access token
+  <pre>
+  curl <b>--header 'Authorization: token $pat_token'</b> https://api.github.com/repos/$repo_owner/$repo_name
+  </pre>
+  * _\`$pat_token\` is a personal authentication token (see [this article](https://help.github.com/en/articles/creating-a-personal-access-token-for-the-command-line))._
+
+Running one of the above curl commands should output a large JSON object of all the repository details, all we want is the "id" field, it should be the first item and be a 9 digit number.
+
+Once you have found the id for your repo, you can use it with the badgen dependabot endpoint like so:
+<pre>
+https://badgen.net/dependabot/badgen/example-private-repo/<b>123456789</b>?icon=dependabot
+</pre>
+`
+
 export const meta: Meta = {
   title: 'Dependabot',
   examples: {
-    '/dependabot/dependabot/dependabot-core/?icon=dependabot': 'status',
-    '/dependabot/greenkeeperio/greenkeeper/<repo_id>?icon=dependabot': 'status (private repo)'
-  }
+    '/dependabot/dependabot/dependabot-core/?icon=dependabot': 'status'
+  },
+  help
 }
 
 export const handlers: Handlers = {
@@ -23,7 +55,7 @@ export default badgenServe(handlers)
 async function handler ({ owner, repo, identifier }: Args) {
   // https://github.com/dependabot/feedback/issues/6#issuecomment-503994253
   let endpoint = `https://api.dependabot.com/badges/status?host=github&repo=${owner}/${repo}`
-  if (!!identifier && identifier !== '<repo_id>') {
+  if (!!identifier) {
     endpoint += `&identifier=${identifier}`
   }
   const { status, colour } = await got(endpoint).then(res => res.body);

--- a/libs/badge-list.ts
+++ b/libs/badge-list.ts
@@ -38,6 +38,7 @@ export const liveBadgeList = [
   'xo',
   'badgesize',
   'jsdelivr',
+  'dependabot',
   // utilities
   'opencollective',
   'keybase',


### PR DESCRIPTION
Based on this conversation: https://github.com/dependabot/feedback/issues/6#issuecomment-503994253

### identifier
Accepts a private repo id, for the example I filtered out `<repo_id>` since I don't have an actual private repo to add (and I don't think it is a good idea), and used greenkeeper because it is a repo I can't see ever implementing dependabot, so it shows both states.

fixes: #283 