### PR TITLE
Combined context status

### DIFF
--- a/endpoints/github.ts
+++ b/endpoints/github.ts
@@ -18,21 +18,17 @@ export const meta: Meta = {
     '/github/release/babel/babel/stable': 'latest stable release',
     '/github/tag/micromatch/micromatch': 'latest tag',
     '/github/watchers/micromatch/micromatch': 'watchers',
-    '/github/status/micromatch/micromatch': 'combined status',
-    '/github/status/micromatch/micromatch/gh-pages': 'combined status (branch ref)',
-    '/github/status/micromatch/micromatch/f4809eb6df80b': 'combined status (commit ref)',
-    '/github/status/micromatch/micromatch/4.0.1': 'combined status (version ref)',
-
-    '/github/status/zeit/hyper/efeedd0a9d3': 'combined status (commit ref)',
-    '/github/status/zeit/hyper/efeedd0a9d3/ci/circleci': 'combined context status',
-    '/github/status/zeit/hyper/efeedd0a9d3/ci/circleci:%20build': 'single context status',
-    '/github/status/zeit/hyper/efeedd0a9d3/continuous-integration/appveyor': 'combined Appveyor status',
-    '/github/status/zeit/hyper/efeedd0a9d3/continuous-integration/travis': 'combined Travis status',
-    '/github/status/zeit/hyper/efeedd0a9d3/continuous-integration': 'combined Travis and Appveyor',
-
-    '/github/status/zeit/now-cli/master/ci/circleci:%20test-unit': 'single context status',
-    '/github/status/facebook/react/master/ci/circleci:%20lint': 'single context status',
-    '/github/status/facebook/react/master/coverage/coveralls': 'single context status',
+    '/github/status/micromatch/micromatch': 'combined ci status',
+    '/github/status/micromatch/micromatch/gh-pages': 'combined ci status (branch ref)',
+    '/github/status/micromatch/micromatch/f4809eb6df80b': 'combined ci status (commit ref)',
+    '/github/status/micromatch/micromatch/4.0.1': 'combined ci status (version ref)',
+    '/github/status/zeit/hyper/efeedd0a9d3': 'combined ci status (commit ref)',
+    '/github/status/zeit/hyper/efeedd0a9d3/ci/circleci': 'combined ci job status',
+    '/github/status/zeit/hyper/efeedd0a9d3/ci/circleci:%20build': 'single ci job status',
+    '/github/status/babel/babel/bdbe8db5660/codecov': 'combined ci job status',
+    '/github/status/zeit/now-cli/master/ci/circleci:%20test-unit': 'single ci job status',
+    '/github/status/facebook/react/master/ci/circleci:%20lint': 'single ci job status',
+    '/github/status/facebook/react/master/coverage/coveralls': 'single ci job status',
     '/github/stars/micromatch/micromatch': 'stars',
     '/github/forks/micromatch/micromatch': 'forks',
     '/github/issues/micromatch/micromatch': 'issues',
@@ -124,9 +120,15 @@ async function status ({ owner, repo, ref = 'master', context }: Args) {
     : resp!.state
 
   if (Array.isArray(state)) {
+    const error = state.find(x => x.state === 'error')
     const failure = state.find(x => x.state === 'failure')
     const pending = state.find(x => x.state === 'pending')
-    state = failure ? 'failure' : (pending ? 'pending' : 'success')
+
+    if (error) {
+      state = 'error'
+    } else {
+      state = failure ? 'failure' : (pending ? 'pending' : 'success')
+    }
   }
 
   if (state) {

--- a/endpoints/github.ts
+++ b/endpoints/github.ts
@@ -88,7 +88,7 @@ const pickGithubToken = () => {
 // request github api v3 (rest)
 const restGithub = path => got.get(`https://api.github.com/${path}`, {
   headers: {
-    Authorization: `token ad544190479f86e4f97e251a98d2180fdc42c5db`,
+    Authorization: `token ${pickGithubToken()}`,
     Accept: 'application/vnd.github.hellcat-preview+json'
   }
 }).then(res => res.body)
@@ -98,7 +98,7 @@ const queryGithub = query => {
   return got.post('https://api.github.com/graphql', {
     body: { query },
     headers: {
-      Authorization: `token ad544190479f86e4f97e251a98d2180fdc42c5db`,
+      Authorization: `token ${pickGithubToken()}`,
       Accept: 'application/vnd.github.hawkgirl-preview+json'
     }
   }).then(res => res.body)

--- a/endpoints/github.ts
+++ b/endpoints/github.ts
@@ -18,13 +18,21 @@ export const meta: Meta = {
     '/github/release/babel/babel/stable': 'latest stable release',
     '/github/tag/micromatch/micromatch': 'latest tag',
     '/github/watchers/micromatch/micromatch': 'watchers',
-    '/github/status/micromatch/micromatch': 'combined ci status',
-    '/github/status/micromatch/micromatch/gh-pages': 'combined ci status (branch ref)',
-    '/github/status/micromatch/micromatch/f4809eb6df80b': 'combined ci status (commit ref)',
-    '/github/status/micromatch/micromatch/4.0.1': 'combined ci status (version ref)',
-    '/github/status/zeit/now-cli/master/ci/circleci:%20test-unit': 'single ci job status',
-    '/github/status/facebook/react/master/ci/circleci:%20lint': 'single ci job status',
-    '/github/status/facebook/react/master/coverage/coveralls': 'single ci job status',
+    '/github/status/micromatch/micromatch': 'combined status',
+    '/github/status/micromatch/micromatch/gh-pages': 'combined status (branch ref)',
+    '/github/status/micromatch/micromatch/f4809eb6df80b': 'combined status (commit ref)',
+    '/github/status/micromatch/micromatch/4.0.1': 'combined status (version ref)',
+
+    '/github/status/zeit/hyper/efeedd0a9d3': 'combined status (commit ref)',
+    '/github/status/zeit/hyper/efeedd0a9d3/ci/circleci': 'combined context status',
+    '/github/status/zeit/hyper/efeedd0a9d3/ci/circleci:%20build': 'single context status',
+    '/github/status/zeit/hyper/efeedd0a9d3/continuous-integration/appveyor': 'combined Appveyor status',
+    '/github/status/zeit/hyper/efeedd0a9d3/continuous-integration/travis': 'combined Travis status',
+    '/github/status/zeit/hyper/efeedd0a9d3/continuous-integration': 'combined Travis and Appveyor',
+
+    '/github/status/zeit/now-cli/master/ci/circleci:%20test-unit': 'single context status',
+    '/github/status/facebook/react/master/ci/circleci:%20lint': 'single context status',
+    '/github/status/facebook/react/master/coverage/coveralls': 'single context status',
     '/github/stars/micromatch/micromatch': 'stars',
     '/github/forks/micromatch/micromatch': 'forks',
     '/github/issues/micromatch/micromatch': 'issues',
@@ -78,7 +86,6 @@ const pickGithubToken = () => {
   }
 
   const tokens = GH_TOKENS.split(',')
-  console.log(tokens)
   return tokens[Math.floor(Math.random() * tokens.length)]
 }
 

--- a/endpoints/github.ts
+++ b/endpoints/github.ts
@@ -78,6 +78,7 @@ const pickGithubToken = () => {
   }
 
   const tokens = GH_TOKENS.split(',')
+  console.log(tokens)
   return tokens[Math.floor(Math.random() * tokens.length)]
 }
 
@@ -111,9 +112,15 @@ const statesColor = {
 async function status ({ owner, repo, ref = 'master', context }: Args) {
   const resp = await restGithub(`repos/${owner}/${repo}/commits/${ref}/status`)
 
-  const state = typeof context === 'string'
-    ? resp!.statuses.find(st => st.context === context).state
+  let state = typeof context === 'string'
+    ? resp!.statuses.filter(st => st.context.startsWith(context))
     : resp!.state
+
+  if (Array.isArray(state)) {
+    const failure = state.find(x => x.state === 'failure')
+    const pending = state.find(x => x.state === 'pending')
+    state = failure ? 'failure' : (pending ? 'pending' : 'success')
+  }
 
   if (state) {
     return {


### PR DESCRIPTION
Maybe we might need to widen a bit the page width. Cuz I think those examples are needed so user can see what and how. I also renamed few examples, because they are not exactly `ci job` or `ci status`, it's a github status, more precisely context status.

![combined-context-status-badgen](https://user-images.githubusercontent.com/5038030/59962307-40b04f80-94ec-11e9-9990-171bcc2948f9.png)

So now don't even need separate live badges for those :D 

Because:

_combined appveyor with custom label and icon_
```
https://badgen.net/github/status/zeit/hyper/efeedd0a9d3/continuous-integration/appveyor?label=windows&icon=appveyor
```

![badgen-windows-appveyor-combined](https://user-images.githubusercontent.com/5038030/59962362-085d4100-94ed-11e9-9f3e-2b65ce37ea5c.png)

_combined travis with custom label and icon_
```
https://badgen.net/github/status/zeit/hyper/efeedd0a9d3/continuous-integration/travis?label=travis&icon=travis
```

![badgen-travis-combined](https://user-images.githubusercontent.com/5038030/59962361-085d4100-94ed-11e9-94de-b02dfaea9435.png)

_combined circleci with custom label and icon_
```
https://badgen.net/github/status/zeit/hyper/efeedd0a9d3/ci:circleci?label=circleci&icon=circleci
```

_combined overall status_
```
https://badgen.net/github/status/zeit/hyper/efeedd0a9d3
```

