### PR TITLE
Resolve iconPromise to undefined by default

### DIFF
--- a/libs/badgen-serve.ts
+++ b/libs/badgen-serve.ts
@@ -46,7 +46,7 @@ export function badgenServe (handlers: BadgenServeHandlers): Function {
       try {
         const paramsPromise = handlers[matchedScheme](matchedArgs)
 
-        let iconPromise
+        let iconPromise: Promise<string | undefined> = Promise.resolve(undefined);
         if (typeof query.icon === 'string') {
           if (query.icon === '') {
             iconPromise = Promise.resolve(defaultLabel)


### PR DESCRIPTION
`.catch` [here](https://github.com/badgen/badgen.net/blob/master/libs/badgen-serve.ts#L61) only exists when a icon query exists, resolving the iconPromise to default allows it to catch regardless.
![image](https://user-images.githubusercontent.com/5557458/60020606-40e55200-9688-11e9-8d2d-45a0dd5bc2ea.png)


fixes: #290 