### PR TITLE
Removes the useless horizontal scrollbar.

### DIFF
--- a/static/index.css
+++ b/static/index.css
@@ -43,7 +43,7 @@ code { font-size: 0.85em; padding: 0.2em; background-color: #f6f8fa; }
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 
-body {width: 100vw}
+body {width: 100%}
 h1 img { height: 42px; position: relative; top: 3px }
 h1 + p { letter-spacing: 0.4px; color: #333; font-size: 20px }
 h1 + p + p { justify-content: center; display: flex; flex-direction: row; margin: 0 auto; }


### PR DESCRIPTION
It appears due to `100vw` but since there is a vertical scrollbar it has only `100vw - scrollbar width` of width.