### PR TITLE
fix: ignore ParsedUrlQuery modification for serve

### DIFF
--- a/libs/badgen-serve.ts
+++ b/libs/badgen-serve.ts
@@ -69,6 +69,7 @@ export function badgenServe (handlers: BadgenServeHandlers): Function {
         params.subject = simpleDecode(params.subject)
         params.status = simpleDecode(params.status)
 
+        // @ts-ignore
         query.icon = icon === '' ? params.subject : icon
 
         if (query.style === undefined) {

--- a/libs/badgen-serve.ts
+++ b/libs/badgen-serve.ts
@@ -69,8 +69,9 @@ export function badgenServe (handlers: BadgenServeHandlers): Function {
         params.subject = simpleDecode(params.subject)
         params.status = simpleDecode(params.status)
 
-        // @ts-ignore
-        query.icon = icon === '' ? params.subject : icon
+        if (icon !== undefined) {
+          query.icon = icon === '' ? params.subject : icon
+        }
 
         if (query.style === undefined) {
           const host = req.headers['x-forwarded-host'] || req.headers.host


### PR DESCRIPTION
Using `yarn dev` was not possible due to an error that was thrown while trying to assign the `icon` property to the `query` variable which only allows properties specified in `ParsedUrlQuery`.

```
72:9 Type 'string | undefined' is not assignable to type 'string | string[]'.
  Type 'undefined' is not assignable to type 'string | string[]'.
    70 |         params.status = simpleDecode(params.status)
    71 |
  > 72 |         query.icon = icon === '' ? params.subject : icon
       |         ^
    73 |
    74 |         if (query.style === undefined) {
    75 |           const host = req.headers['x-forwarded-host'] || req.headers.host

> Build error occurred
```