### PR TITLE
Add support for Libraries.io dependency status

### DIFF
--- a/endpoints/librariesio.ts
+++ b/endpoints/librariesio.ts
@@ -1,0 +1,58 @@
+import {
+  badgenServe,
+  BadgenServeHandlerArgs as Args,
+  BadgenServeHandlers as Handlers,
+  BadgenServeMeta as Meta
+} from '../libs/badgen-serve'
+import got from '../libs/got'
+
+export const meta: Meta = {
+  title: 'Libraries.io',
+  examples: {
+    '/librariesio/github/i4004/Simplify': 'dependency status'
+  }
+}
+
+export const handlers: Handlers = {
+  '/librariesio/github/:user/:repo': handler
+}
+
+export default badgenServe(handlers)
+
+const uriBase = 'https://libraries.io/api/github/'
+
+async function handler ({ user, repo }: Args) {
+  const subject = 'dependencies'
+  const deps = await got(`${uriBase}/${user}/${repo}/dependencies`).then(res => res.body.dependencies)
+  const [outdated, deprecated] = deps.reduce(([out, dep], x) => [out += x.outdated ? 1 : 0, dep += x.deprecated ? 1 : 0], [0, 0])
+
+  if (deprecated > 0 && outdated > 0) {
+    return {
+      subject,
+      status: `${deprecated} deprecated, ${outdated} outdated`,
+      color: 'red'
+    }    
+  }
+
+  if (deprecated > 0) {
+    return {
+      subject,
+      status: `${deprecated} deprecated`,
+      color: 'red'
+    }    
+  }
+
+  if (outdated > 0) {
+    return {
+      subject,
+      status: `${outdated} outdated`,
+      color: 'orange'
+    }
+  }
+
+  return {
+    subject,
+    status: 'up to date',
+    color: 'green'
+  }
+}

--- a/libs/badge-list.ts
+++ b/libs/badge-list.ts
@@ -40,6 +40,8 @@ export const liveBadgeList = [
   'badgesize',
   'jsdelivr',
   'dependabot',
+  // dependencies
+  'librariesio',
   // utilities
   'opencollective',
   'keybase',


### PR DESCRIPTION
This PR adds Libraries.io support to Badgen. In particular, it will generate a badge that lists the dependency status for a Github repository. Dependencies for the repository are examined from the Libraries.io API endpoint. Badges are generated on the following conditions:

* If the repository uses both deprecated and outdated dependencies, then a red `x deprecated, y outdated` badge is displayed.
* If the repository uses only deprecated dependencies, then a red `x deprecated` badge is displayed.
* If the repository uses only outdated dependencies, then an orange `y outdated` badge is displayed.
* If the repository uses dependencies that are up to date, then a green `up to date` badge is displayed.