### PR TITLE
Fix badgesize url

### DIFF
--- a/api/badgesize.ts
+++ b/api/badgesize.ts
@@ -7,7 +7,7 @@ export default createBadgenHandler({
     '/badgesize/normal/amio/emoji.json/master/emoji-compact.json': 'normal size',
     '/badgesize/brotli/amio/emoji.json/master/emoji-compact.json': 'brotli size',
     '/badgesize/gzip/amio/emoji.json/master/emoji-compact.json': 'gzip size',
-    '/badgesize/normal/unpkg.com/snarkdown/dist/snarkdown.js': 'arbitrary url',
+    '/badgesize/normal/https/unpkg.com/snarkdown/dist/snarkdown.js': 'arbitrary url',
   },
   handlers: {
     '/badgesize/:topic/:path+': handler
@@ -15,7 +15,16 @@ export default createBadgenHandler({
 })
 
 async function handler ({ topic, path }: PathArgs) {
-  const endpoint = `https://img.badgesize.io/https://${path}.json`
+  if (path.startsWith('http/')) {
+    path = path.slice(0, 4) + ':/' + path.slice(4);
+  } else if (path.startsWith('https/')) {
+    path = path.slice(0, 5) + ':/' + path.slice(5);
+  } else if (path.startsWith('http:/')) {
+    path = path.slice(0, 5) + '/' + path.slice(5);
+  } else if (path.startsWith('https:/')) {
+    path = path.slice(0, 6) + '/' + path.slice(6);
+  }
+  const endpoint = `https://img.badgesize.io/${path}.json`
   const { prettySize, color } = await got(endpoint, {
     query: {
       compression: topic === 'normal' ? '' : topic

--- a/api/badgesize.ts
+++ b/api/badgesize.ts
@@ -7,7 +7,7 @@ export default createBadgenHandler({
     '/badgesize/normal/amio/emoji.json/master/emoji-compact.json': 'normal size',
     '/badgesize/brotli/amio/emoji.json/master/emoji-compact.json': 'brotli size',
     '/badgesize/gzip/amio/emoji.json/master/emoji-compact.json': 'gzip size',
-    '/badgesize/normal/https://unpkg.com/snarkdown/dist/snarkdown.js': 'arbitrary url',
+    '/badgesize/normal/unpkg.com/snarkdown/dist/snarkdown.js': 'arbitrary url',
   },
   handlers: {
     '/badgesize/:topic/:path+': handler
@@ -15,7 +15,7 @@ export default createBadgenHandler({
 })
 
 async function handler ({ topic, path }: PathArgs) {
-  const endpoint = `https://img.badgesize.io/${path}.json`
+  const endpoint = `https://img.badgesize.io/https://${path}.json`
   const { prettySize, color } = await got(endpoint, {
     query: {
       compression: topic === 'normal' ? '' : topic


### PR DESCRIPTION
Double slashes are redirected to a single slash so one solution here is to omit the double slash.