### PR TITLE
chore: update now.json to use all regions

### DIFF
--- a/now.json
+++ b/now.json
@@ -1,6 +1,6 @@
 {
   "version": 2,
-  "regions": ["sfo", "lhr", "hnd"],
+  "regions": ["all"],
   "builds": [
     { "src": "package.json", "use": "@now/static-build" },
     { "src": "api/*.ts", "use": "@now/node" }


### PR DESCRIPTION
It doesn't look like there is any central database dependency so you could run badgen in all regions.

See comment from @XhmikosR here https://github.com/styfle/packagephobia/pull/470#issuecomment-558744451