### PR TITLE
Add Docker image size support

### DIFF
--- a/api/docker.ts
+++ b/api/docker.ts
@@ -8,9 +8,9 @@ export default createBadgenHandler({
     '/docker/pulls/library/ubuntu': 'pulls (library)',
     '/docker/stars/library/ubuntu': 'stars (library)',
     '/docker/size/library/ubuntu': 'size (library)',
-    '/docker/size/library/ubuntu/latest/amd64': 'size (library/tag/architecture)',
     '/docker/pulls/amio/node-chrome': 'pulls (scoped)',
     '/docker/stars/library/mongo?icon=docker&label=stars': 'stars (icon & label)',
+    '/docker/size/lukechilds/bitcoind/latest/amd64': 'size (scoped/tag/architecture)',
   },
   handlers: {
     '/docker/:topic<stars|pulls>/:scope/:name': starPullHandler,

--- a/api/docker.ts
+++ b/api/docker.ts
@@ -7,13 +7,14 @@ export default createBadgenHandler({
   examples: {
     '/docker/pulls/library/ubuntu': 'pulls (library)',
     '/docker/stars/library/ubuntu': 'stars (library)',
-    '/docker/size/library/ubuntu/latest/amd64': 'size (library)',
+    '/docker/size/library/ubuntu': 'size (library)',
+    '/docker/size/library/ubuntu/latest/amd64': 'size (library/tag/architecture)',
     '/docker/pulls/amio/node-chrome': 'pulls (scoped)',
     '/docker/stars/library/mongo?icon=docker&label=stars': 'stars (icon & label)',
   },
   handlers: {
     '/docker/:topic<stars|pulls>/:scope/:name': starPullHandler,
-    '/docker/size/:scope/:name/:tag/:architecture': sizeHandler
+    '/docker/size/:scope/:name/:tag?/:architecture?': sizeHandler
   }
 })
 
@@ -47,6 +48,8 @@ async function starPullHandler ({ topic, scope, name }: PathArgs) {
 }
 
 async function sizeHandler ({ scope, name, tag, architecture }: PathArgs) {
+  tag = tag ? tag : 'latest'
+  architecture = architecture ? architecture : 'amd64'
   /* eslint-disable camelcase */
   const endpoint = `https://hub.docker.com/v2/repositories/${scope}/${name}/tags`
   let body = await got(endpoint).then(res => res.body)

--- a/api/docker.ts
+++ b/api/docker.ts
@@ -49,7 +49,14 @@ async function starPullHandler ({ topic, scope, name }: PathArgs) {
 async function sizeHandler ({ scope, name, tag }: PathArgs) {
   /* eslint-disable camelcase */
   const endpoint = `https://hub.docker.com/v2/repositories/${scope}/${name}/tags`
-  const { results } = await got(endpoint).then(res => res.body)
+  let body = await got(endpoint).then(res => res.body)
+
+  let results = [...body.results]
+  while (body.next) {
+    body = await got(body.next).then(res => res.body)
+    results = [...results, ...body.results]
+  }
+
   const tagData = results.find(tagData => tagData.name === tag)
 
   if (!tagData) {


### PR DESCRIPTION
Shows the size for a Docker image.

Defaults to the latest tag and amd64 architecture as they are most popular but a  custom tag or arch can optionally be specified with `/docker/size/:scope/:name/:tag?/:architecture?`.

<img width="793" alt="Screenshot 2019-12-11 at 19 21 20" src="https://user-images.githubusercontent.com/2123375/70621146-7c320800-1c4b-11ea-9552-9f51f499611f.png">

Notes:

- `/docker/size/library/ubuntu` is a little slow, I've re-used the ubuntu image as that's what's in the other library examples. The reason it's slow is it has to paginate through a lot of API responses to find the tag as there are a huge amount of tags on Docker Hub for Ubuntu.
- I'm manually calculating the size instead of using `millify` because `millify` calculates MB when what we actually want is MiB to be consistent with the Docker Hub UI.
