### PR TITLE
badge(npm): always follow versionColor

### DIFF
--- a/api/npm.ts
+++ b/api/npm.ts
@@ -87,7 +87,7 @@ async function info (topic: string, pkg: string, tag = 'latest') {
       return {
         subject: tag === 'latest' ? 'npm' : `npm@${tag}`,
         status: version(meta.version),
-        color: tag === 'latest' ? versionColor(meta.version) : 'blue'
+        color: versionColor(meta.version)
       }
     }
     case 'license': {


### PR DESCRIPTION
no matter the dist-tag it should follow the versionColor