### PR TITLE
Add .git to .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,4 @@
 .github
 node_modules
 dist
+.git


### PR DESCRIPTION
This prevents cache busting while building the Docker Image when only some git data changes like doing a fetching or rebasing without actual changes.