### PR TITLE
Filter out empty GitHub tokens

### DIFF
--- a/api/github.ts
+++ b/api/github.ts
@@ -76,7 +76,7 @@ const pickGithubToken = () => {
     })
   }
 
-  const tokens = GH_TOKENS.split(',')
+  const tokens = GH_TOKENS.split(',').filter(function(el) {return el.length != 0})
   return tokens[Math.floor(Math.random() * tokens.length)]
 }
 


### PR DESCRIPTION
I had specific the GitHub token like this ``GH_TOKENS=xxxxx,`` and 50% of the requests didn't use a token and failed because of that. To not run into this issue again by accident I filtered out empty results after the split.