### PR TITLE
Homebrew: add cask version & download analytics support

### DIFF
--- a/api/homebrew.ts
+++ b/api/homebrew.ts
@@ -6,20 +6,27 @@ export default createBadgenHandler({
   title: 'Homebrew',
   examples: {
     '/homebrew/v/fish': 'version',
-    '/homebrew/v/cake': 'version'
+    '/homebrew/v/cake': 'version',
+    '/homebrew/cask/v/atom': 'version',
+    '/homebrew/cask/v/whichspace': 'version'
   },
   handlers: {
-    '/homebrew/v/:pkg': handler
+    '/homebrew/v/:pkg': handler,
+    '/homebrew/:type<formula|cask>/v/:pkg': handler
   }
 })
 
-async function handler ({ pkg }: PathArgs) {
-  const endpoint = `https://formulae.brew.sh/api/formula/${pkg}.json`
-  const { versions } = await got(endpoint).json<any>()
+async function handler ({ type = 'formula', pkg }: PathArgs) {
+  const endpoint = `https://formulae.brew.sh/api/${type}/${pkg}.json`
+  const subject = type === 'cask' ? 'homebrew cask' : 'homebrew'
+  const {
+    versions,
+    version:ver = versions.stable
+  } = await got(endpoint).json<any>()
 
   return {
-    subject: 'homebrew',
-    status: version(versions.stable),
-    color: versionColor(versions.stable)
+    subject,
+    status: version(ver),
+    color: versionColor(ver)
   }
 }

--- a/api/homebrew.ts
+++ b/api/homebrew.ts
@@ -1,5 +1,5 @@
 import got from '../libs/got'
-import { version, versionColor } from '../libs/utils'
+import { millify, version, versionColor } from '../libs/utils'
 import { createBadgenHandler, PathArgs } from '../libs/create-badgen-handler'
 
 export default createBadgenHandler({
@@ -7,26 +7,46 @@ export default createBadgenHandler({
   examples: {
     '/homebrew/v/fish': 'version',
     '/homebrew/v/cake': 'version',
+    '/homebrew/dm/fish': 'monthly downloads',
+    '/homebrew/dy/fish': 'yearly downloads',
     '/homebrew/cask/v/atom': 'version',
     '/homebrew/cask/v/whichspace': 'version'
+    // NOTE: cask analytics are broken
+    // '/homebrew/cask/dm/atom': 'monthly downloads',
+    // '/homebrew/cask/dy/atom': 'yearly downloads'
   },
   handlers: {
-    '/homebrew/v/:pkg': handler,
-    '/homebrew/:type<formula|cask>/v/:pkg': handler
+    '/homebrew/:topic<v|dm|dy>/:pkg': handler,
+    '/homebrew/:type<formula|cask>/:topic<v|dm|dy>/:pkg': handler
   }
 })
 
-async function handler ({ type = 'formula', pkg }: PathArgs) {
+async function handler ({ type = 'formula', topic, pkg }: PathArgs) {
   const endpoint = `https://formulae.brew.sh/api/${type}/${pkg}.json`
-  const subject = type === 'cask' ? 'homebrew cask' : 'homebrew'
   const {
+    analytics,
     versions,
     version:ver = versions.stable
   } = await got(endpoint).json<any>()
 
-  return {
-    subject,
-    status: version(ver),
-    color: versionColor(ver)
+  switch (topic) {
+    case 'v':
+      return {
+        subject: type === 'cask' ? 'homebrew cask' : 'homebrew',
+        status: version(ver),
+        color: versionColor(ver)
+      }
+    case 'dm':
+      return {
+        subject: 'downloads',
+        status: millify(analytics.install['30d'][pkg]) + '/month',
+        color: 'green'
+      }
+    case 'dy':
+      return {
+        subject: 'downloads',
+        status: millify(analytics.install['365d'][pkg]) + '/year',
+        color: 'green'
+      }
   }
 }


### PR DESCRIPTION
Homebrew supports API data access for both formulas and casks:
- for formulas
	`https://formulae.brew.sh/api/formula/<name>.json`
- for casks
	`https://formulae.brew.sh/api/cask/<name>.json`

This PR adds support for displaying cask versions and download analytics for formulas.

This adds new `/homebrew` route subroutes:
- for download analytics (monthly & yearly downloads)
	```
	/homebrew/dm/:pkg
	/homebrew/dy/:pkg
	```
- for displaying cask version
	```
	/homebrew/cask/v/:pkg
	```

## Before
<img src="https://user-images.githubusercontent.com/1170440/81187187-004aaa80-8fb4-11ea-970a-0472e16b1ab1.png" width="600">

---
## After
![image](https://user-images.githubusercontent.com/1170440/81187141-ed37da80-8fb3-11ea-9a86-f7d7d0f97ecf.png)
