### PR TITLE
Add haxelib service

### DIFF
--- a/api/haxelib.ts
+++ b/api/haxelib.ts
@@ -1,6 +1,6 @@
 import RpcClient from 'haxe-rpc-client'
 import { millify, version, versionColor } from '../libs/utils'
-import { createBadgenHandler, PathArgs } from '../libs/create-badgen-handler'
+import { createBadgenHandler, PathArgs, BadgenError } from '../libs/create-badgen-handler'
 
 const HAXELIB_RPC_URL = 'https://lib.haxe.org/api/3.0/index.n'
 
@@ -9,8 +9,15 @@ class HaxelibClient extends RpcClient {
     super(HAXELIB_RPC_URL)
   }
 
-  info(project) {
-    return this.call<any>('api.infos', [project])
+  async info(project) {
+    try {
+      return await this.call<any>('api.infos', [project])
+    } catch (err) {
+      if (err.message.startsWith('No such Project')) {
+        throw new BadgenError({ status: 404 })
+      }
+      throw err
+    }
   }
 }
 

--- a/api/haxelib.ts
+++ b/api/haxelib.ts
@@ -20,6 +20,7 @@ export default createBadgenHandler({
     '/haxelib/v/tink_http': 'version',
     '/haxelib/v/nme': 'version',
     '/haxelib/d/hxnodejs': 'downloads',
+    '/haxelib/dl/hxnodejs': 'downloads (latest version)',
     '/haxelib/license/openfl': 'license'
   },
   handlers: {
@@ -29,7 +30,12 @@ export default createBadgenHandler({
 
 async function handler ({ topic, project }: PathArgs) {
   const client = new HaxelibClient()
-  const { curversion: ver, downloads, license } = await client.info(project)
+  const {
+    downloads,
+    license,
+    curversion: ver,
+    versions
+  } = await client.info(project)
 
   switch (topic) {
     case 'v': {
@@ -50,6 +56,14 @@ async function handler ({ topic, project }: PathArgs) {
       return {
         subject: 'downloads',
         status: millify(downloads),
+        color: 'green'
+      }
+    }
+    case 'dl': {
+      const latestVersion = versions.find(it => it.name === ver)
+      return {
+        subject: 'downloads',
+        status: millify(latestVersion.downloads) + ' latest version',
         color: 'green'
       }
     }

--- a/api/haxelib.ts
+++ b/api/haxelib.ts
@@ -1,0 +1,57 @@
+import RpcClient from 'haxe-rpc-client'
+import { millify, version, versionColor } from '../libs/utils'
+import { createBadgenHandler, PathArgs } from '../libs/create-badgen-handler'
+
+const HAXELIB_RPC_URL = 'https://lib.haxe.org/api/3.0/index.n'
+
+class HaxelibClient extends RpcClient {
+  constructor() {
+    super(HAXELIB_RPC_URL)
+  }
+
+  info(project) {
+    return this.call<any>('api.infos', [project])
+  }
+}
+
+export default createBadgenHandler({
+  title: 'haxelib',
+  examples: {
+    '/haxelib/v/tink_http': 'version',
+    '/haxelib/v/nme': 'version',
+    '/haxelib/d/hxnodejs': 'downloads',
+    '/haxelib/license/openfl': 'license'
+  },
+  handlers: {
+    '/haxelib/:topic/:project': handler
+  }
+})
+
+async function handler ({ topic, project }: PathArgs) {
+  const client = new HaxelibClient()
+  const { curversion: ver, downloads, license } = await client.info(project)
+
+  switch (topic) {
+    case 'v': {
+      return {
+        subject: 'haxelib',
+        status: version(ver),
+        color: versionColor(ver)
+      }
+    }
+    case 'license': {
+      return {
+        subject: 'license',
+        status: license || 'unknown',
+        color: 'blue'
+      }
+    }
+    case 'd': {
+      return {
+        subject: 'downloads',
+        status: millify(downloads),
+        color: 'green'
+      }
+    }
+  }
+}

--- a/libs/badge-list.ts
+++ b/libs/badge-list.ts
@@ -26,6 +26,7 @@ export const liveBadgeList = [
   'vs-marketplace',
   'maven',
   'cocoapods',
+  'haxelib',
   // CI
   'travis',
   'circleci',

--- a/package-lock.json
+++ b/package-lock.json
@@ -5402,6 +5402,11 @@
         "minimalistic-assert": "^1.0.1"
       }
     },
+    "haxe-rpc-client": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/haxe-rpc-client/-/haxe-rpc-client-1.0.0.tgz",
+      "integrity": "sha512-AffqK18IUrPB1NL9GK6N1NvOFoeTTJxwXSscO/DydzeOyJ2qbZC17mZNTLlWHEEmfnbRAEjvHT48OiXGO1GAAA=="
+    },
     "hex-color-regex": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/hex-color-regex/-/hex-color-regex-1.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "chrome-webstore": "^1.3.1",
     "date-fns": "^2.12.0",
     "got": "^10.7.0",
+    "haxe-rpc-client": "^1.0.0",
     "lodash.debounce": "^4.0.8",
     "measurement-protocol": "^0.1.1",
     "micro": "^9.3.4",


### PR DESCRIPTION
Fetch library information from https://lib.haxe.org using [`haxe-rpc-client`](https://npm.im/haxe-rpc-client).

This adds a new handler:
```
/haxelib/:topic/:project
```
where the topic can be one of:
- `v` (version)
- `d` (downloads)
- `dl` (downloads latest version)
- `license`

## Preview

![image](https://user-images.githubusercontent.com/1170440/81175090-3a5f8080-8fa3-11ea-8780-7e475509f1a9.png)