### PR TITLE
Add Scoop badge

### DIFF
--- a/api/scoop.ts
+++ b/api/scoop.ts
@@ -1,0 +1,42 @@
+import got from '../libs/got'
+import { version, versionColor } from '../libs/utils'
+import { createBadgenHandler, PathArgs } from '../libs/create-badgen-handler'
+
+const SCOOP_MAIN_BUCKET_URL = 'https://github.com/ScoopInstaller/Main/raw/master/bucket/'
+const SCOOP_EXTRAS_BUCKET_URL = 'https://github.com/lukesampson/scoop-extras/raw/master/bucket/'
+
+export default createBadgenHandler({
+  title: 'Scoop',
+  examples: {
+    '/scoop/v/1password-cli': 'version',
+    '/scoop/v/adb': 'version',
+    '/scoop/license/caddy': 'license',
+    '/scoop/extras/v/age': 'version',
+    '/scoop/extras/v/codeblocks': 'version',
+    '/scoop/extras/license/deluge': 'license',
+  },
+  handlers: {
+    '/scoop/:topic<v|license>/:app': handler,
+    '/scoop/:bucket<main|extras>/:topic<v|license>/:app': handler
+  }
+})
+
+async function handler ({ bucket = 'main', topic = 'v', app }: PathArgs) {
+  const prefixUrl = bucket === 'extras' ? SCOOP_EXTRAS_BUCKET_URL : SCOOP_MAIN_BUCKET_URL
+  const { license, version:ver } = await got(`${app}.json`, { prefixUrl }).json<any>()
+
+  switch (topic) {
+    case 'v':
+      return {
+        subject: bucket === 'extras' ? 'scoop-extras' : 'scoop',
+        status: version(ver),
+        color: versionColor(ver)
+      }
+    case 'license':
+      return {
+        subject: 'license',
+        status: license || 'unknown',
+        color: 'blue'
+      }
+  }
+}

--- a/libs/badge-list.ts
+++ b/libs/badge-list.ts
@@ -27,6 +27,7 @@ export const liveBadgeList = [
   'maven',
   'cocoapods',
   'haxelib',
+  'scoop',
   // CI
   'travis',
   'circleci',


### PR DESCRIPTION
[Scoop](https://github.com/lukesampson/scoop) is a command-line package installer for Windows.
The app information is fetched from either [main](https://github.com/ScoopInstaller/Main/tree/master/bucket) or [extras](https://github.com/lukesampson/scoop-extras/tree/master/bucket) bucket hosting json manifests.

This adds two new handlers:
```
/scoop/:topic<v|license>/:app
/scoop/:bucket<main|extras>/:topic<v|license>/:app
```
where the topic can be one of:
- `v` (version)
- `license`

## Preview

![image](https://user-images.githubusercontent.com/1170440/82161587-5a921800-989e-11ea-9c4a-b0741cfa41fa.png)
