### PR TITLE
Add F-Droid support

### DIFF
--- a/api/f-droid.ts
+++ b/api/f-droid.ts
@@ -1,0 +1,44 @@
+import got from '../libs/got'
+import { parseDocument } from 'yaml'
+import { version, versionColor } from '../libs/utils'
+import { createBadgenHandler, PathArgs } from '../libs/create-badgen-handler'
+
+const F_DROID_METADATA_REPO_URL = 'https://gitlab.com/fdroid/fdroiddata/raw/master/metadata/'
+
+const client = got.extend({ prefixUrl: F_DROID_METADATA_REPO_URL })
+
+export default createBadgenHandler({
+  title: 'F-Droid',
+  examples: {
+    '/f-droid/v/org.schabi.newpipe': 'version',
+    '/f-droid/v/com.amaze.filemanager': 'version',
+    '/f-droid/license/org.tasks': 'license'
+  },
+  handlers: {
+    '/f-droid/:topic<v|license>/:appId': handler
+  }
+})
+
+async function handler ({ topic, appId }: PathArgs) {
+  const yaml = await client.get(`${appId}.yml`).text()
+  const metadata = parseDocument(yaml)
+
+  switch (topic) {
+    case 'v': {
+      const ver = metadata.get('CurrentVersion')
+      return {
+        subject: 'f-droid',
+        status: version(ver),
+        color: versionColor(ver)
+      }
+    }
+    case 'license': {
+      const license = metadata.get('License')
+      return {
+        subject: 'license',
+        status: license || 'unknown',
+        color: 'blue'
+      }
+    }
+  }
+}

--- a/libs/badge-list.ts
+++ b/libs/badge-list.ts
@@ -29,6 +29,7 @@ export const liveBadgeList = [
   'haxelib',
   'opam',
   'scoop',
+  'f-droid',
   // CI
   'travis',
   'circleci',

--- a/package-lock.json
+++ b/package-lock.json
@@ -11379,6 +11379,11 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true
     },
+    "yaml": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.0.tgz",
+      "integrity": "sha512-yr2icI4glYaNG+KWONODapy2/jDdMSDnrONSjblABjD9B4Z5LgiircSt8m8sRZFNi08kG9Sm0uSHtEmP3zaEGg=="
+    },
     "yargs": {
       "version": "14.2.2",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-14.2.2.tgz",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "semver": "^7.3.2",
     "serve-handler": "^6.1.2",
     "serve-marked": "^2.0.2",
-    "url-parse": "^1.4.7"
+    "url-parse": "^1.4.7",
+    "yaml": "^1.10.0"
   },
   "devDependencies": {
     "@types/cheerio": "^0.22.17",


### PR DESCRIPTION
Reads app metadata from https://gitlab.com/fdroid/fdroiddata

This adds a new handler:
```
/f-droid/:topic<v|license>/:appId
```
where the topic can be one of:
- `v` (version)
- `license`

## Preview

![image](https://user-images.githubusercontent.com/1170440/82335921-3cd1c980-99ea-11ea-9a6f-4c84e57e1dfc.png)
