### PR TITLE
Add Tidelift subscription badge

### DIFF
--- a/api/tidelift.ts
+++ b/api/tidelift.ts
@@ -1,0 +1,36 @@
+import got from '../libs/got'
+import { basename, extname } from 'path'
+import { createBadgenHandler, PathArgs } from '../libs/create-badgen-handler'
+
+const TIDELIFT_BADGE_URL = 'https://tidelift.com/badges/package/'
+
+const client = got.extend({ prefixUrl: TIDELIFT_BADGE_URL })
+
+export default createBadgenHandler({
+  title: 'Tidelift',
+  examples: {
+    '/tidelift/npm/minimist': 'subscription',
+    '/tidelift/npm/got': 'subscription'
+  },
+  handlers: {
+    '/tidelift/:platform/:name': handler
+  }
+})
+
+async function handler ({ platform, name }: PathArgs) {
+  const resp = await client.get(`${platform}/${name}`, { followRedirect: false })
+  // this shouldn't happen, but in case it happens
+  if (!resp.headers.location) {
+    throw new Error(`Unknown Tidelift status: ${platform}/${name}`)
+  }
+  const { pathname } = new URL(resp.headers.location)
+  const [status, color] = decodeURIComponent(basename(pathname, extname(pathname)))
+    .split('-')
+    .filter(Boolean)
+
+  return {
+    subject: 'tidelift',
+    status,
+    color
+  }
+}

--- a/libs/badge-list.ts
+++ b/libs/badge-list.ts
@@ -49,6 +49,7 @@ export const liveBadgeList = [
   'opencollective',
   'keybase',
   'twitter',
+  'tidelift',
   'runkit',
   'https',
 ]


### PR DESCRIPTION
Reads Tidelift subscription status from their badge. (As explained here: https://github.com/badgen/badgen.net/issues/359#issue-570948860)

This adds a new handler:
```
/tidelift/:platform/:name
```

## Preview

![image](https://user-images.githubusercontent.com/1170440/82340816-f54e3c00-99ef-11ea-9853-9591315efb8d.png)

