### PR TITLE
Add Snyk support

### DIFF
--- a/api/snyk.ts
+++ b/api/snyk.ts
@@ -1,20 +1,20 @@
 import cheerio from 'cheerio'
 import got from '../libs/got'
-import { createBadgenHandler, PathArgs, Query } from '../libs/create-badgen-handler'
+import { createBadgenHandler, PathArgs } from '../libs/create-badgen-handler'
 
 export default createBadgenHandler({
   title: 'Snyk',
   examples: {
     '/snyk/badgen/badgen.net': 'vulnerability scan',
     '/snyk/babel/babel/6.x': 'vulnerability scan (branch)',
-    '/snyk/tunnckoCore/opensource?targetFile=@tunnckocore/utils/package.json': 'vulnerability scan (custom path)'
+    '/snyk/tunnckoCore/opensource/master/@tunnckocore%2Futils%2Fpackage.json': 'vulnerability scan (custom path)'
   },
   handlers: {
-    '/snyk/:user/:repo/:branch?': handler
+    '/snyk/:user/:repo/:branch?/:targetFile?': handler
   }
 })
 
-async function handler ({ user, repo, branch = 'master' }: PathArgs, { targetFile }: Query) {
+async function handler ({ user, repo, branch = 'master', targetFile }: PathArgs) {
   const badgeUrl = `https://snyk.io/test/github/${user}/${repo}/${branch}/badge.svg`
   const searchParams = new URLSearchParams()
   if (targetFile) searchParams.set('targetFile', targetFile)
@@ -24,15 +24,15 @@ async function handler ({ user, repo, branch = 'master' }: PathArgs, { targetFil
   const $color = $('g[mask] path')
     .filter((_, el) => el.attribs.d?.startsWith('M90'))
     .first()
-    
+
   const $subject = $('g text')
     .filter((_, el) => parseInt(el.attribs.x, 10) === 45)
     .first()
-  
+
   const $status = $('g text')
     .filter((_, el) => parseInt(el.attribs.x, 10) === 100)
     .first()
-  
+
   const subject = $subject.text().trim() || 'vulnerabilities'
   const status = $status.text().trim()
   const color = ($color.attr('fill')?.trim() || '').replace(/^#/, '')

--- a/api/snyk.ts
+++ b/api/snyk.ts
@@ -1,0 +1,49 @@
+import cheerio from 'cheerio'
+import got from '../libs/got'
+import { createBadgenHandler, PathArgs, Query } from '../libs/create-badgen-handler'
+
+export default createBadgenHandler({
+  title: 'Snyk',
+  examples: {
+    '/snyk/badgen/badgen.net': 'vulnerability scan',
+    '/snyk/babel/babel/6.x': 'vulnerability scan (branch)',
+    '/snyk/tunnckoCore/opensource?targetFile=@tunnckocore/utils/package.json': 'vulnerability scan (custom path)'
+  },
+  handlers: {
+    '/snyk/:user/:repo/:branch?': handler
+  }
+})
+
+async function handler ({ user, repo, branch = 'master' }: PathArgs, { targetFile }: Query) {
+  const badgeUrl = `https://snyk.io/test/github/${user}/${repo}/${branch}/badge.svg`
+  const searchParams = new URLSearchParams()
+  if (targetFile) searchParams.set('targetFile', targetFile)
+  const svg = await got(badgeUrl, { searchParams }).text()
+  const $ = cheerio.load(svg, { xmlMode: true })
+
+  const $color = $('g[mask] path')
+    .filter((_, el) => el.attribs.d?.startsWith('M90'))
+    .first()
+    
+  const $subject = $('g text')
+    .filter((_, el) => parseInt(el.attribs.x, 10) === 45)
+    .first()
+  
+  const $status = $('g text')
+    .filter((_, el) => parseInt(el.attribs.x, 10) === 100)
+    .first()
+  
+  const subject = $subject.text().trim() || 'vulnerabilities'
+  const status = $status.text().trim()
+  const color = ($color.attr('fill')?.trim() || '').replace(/^#/, '')
+
+  if (!status || !color) {
+    const context = [
+      `${user}/${repo}/${branch}`,
+      targetFile && `targetFile=${targetFile}`
+    ].filter(Boolean).join(' ')
+    throw new Error(`Unknown Synk status: ${context}`)
+  }
+
+  return { subject, status, color }
+}

--- a/libs/badge-list.ts
+++ b/libs/badge-list.ts
@@ -41,6 +41,7 @@ export const liveBadgeList = [
   'codeclimate',
   'azure-pipelines',
   // quality & metrics
+  'snyk',
   'lgtm',
   'uptime-robot',
   'xo',

--- a/libs/create-badgen-handler.ts
+++ b/libs/create-badgen-handler.ts
@@ -11,10 +11,9 @@ import sentry from './sentry'
 import { BadgenParams } from './types'
 
 export type PathArgs = NonNullable<ReturnType<typeof matchRoute>>
-export type Query = NonNullable<Record<string, string | undefined>>
 
 export interface BadgeMaker {
-  (pathArgs: PathArgs, query: Query) : Promise<BadgenParams | undefined>;
+  (pathArgs: PathArgs) : Promise<BadgenParams | undefined>;
 }
 
 export interface BadgenServeConfig {
@@ -76,7 +75,7 @@ export function createBadgenHandler (conf: BadgenServeConfig): BadgenHandler {
 
     // Serve badge
     try {
-      const badgeParamsPromise = conf.handlers[matchedScheme](matchedArgs || {}, query || {})
+      const badgeParamsPromise = conf.handlers[matchedScheme](matchedArgs || {})
 
       let iconPromise: Promise<string | undefined> = Promise.resolve(undefined)
       if (typeof query.icon === 'string') {

--- a/libs/create-badgen-handler.ts
+++ b/libs/create-badgen-handler.ts
@@ -11,9 +11,10 @@ import sentry from './sentry'
 import { BadgenParams } from './types'
 
 export type PathArgs = NonNullable<ReturnType<typeof matchRoute>>
+export type Query = { [key: string]: string | undefined }
 
 export interface BadgeMaker {
-  (pathArgs: PathArgs) : Promise<BadgenParams | undefined>;
+  (pathArgs: PathArgs, query: Query) : Promise<BadgenParams | undefined>;
 }
 
 export interface BadgenServeConfig {
@@ -75,7 +76,7 @@ export function createBadgenHandler (conf: BadgenServeConfig): BadgenHandler {
 
     // Serve badge
     try {
-      const badgeParamsPromise = conf.handlers[matchedScheme](matchedArgs || {})
+      const badgeParamsPromise = conf.handlers[matchedScheme](matchedArgs || {}, query || {})
 
       let iconPromise: Promise<string | undefined> = Promise.resolve(undefined)
       if (typeof query.icon === 'string') {

--- a/libs/create-badgen-handler.ts
+++ b/libs/create-badgen-handler.ts
@@ -11,7 +11,7 @@ import sentry from './sentry'
 import { BadgenParams } from './types'
 
 export type PathArgs = NonNullable<ReturnType<typeof matchRoute>>
-export type Query = { [key: string]: string | undefined }
+export type Query = NonNullable<Record<string, string | undefined>>
 
 export interface BadgeMaker {
   (pathArgs: PathArgs, query: Query) : Promise<BadgenParams | undefined>;


### PR DESCRIPTION
Vulnerability scan results are parsed from official Snyk's badge using `cheerio`.

This adds a new handler:
```
/snyk/:user/:repo/:branch?
```
Additionally `targetFile` query param can be passed to the handler.

## Preview

![image](https://user-images.githubusercontent.com/1170440/82454277-d9ab6a00-9ab1-11ea-85fb-7015126bdd52.png)

This closes #340  