### PR TITLE
Add Mastodon/Pleroma support

### DIFF
--- a/api/mastodon.ts
+++ b/api/mastodon.ts
@@ -1,0 +1,26 @@
+import got from '../libs/got'
+import { millify } from '../libs/utils'
+import { createBadgenHandler, PathArgs } from '../libs/create-badgen-handler'
+
+export default createBadgenHandler({
+  title: 'Mastodon/Pleroma',
+  examples: {
+    '/mastodon/follow/1': 'followers count (mastodon.social)',
+    '/mastodon/follow/1/mas.to': 'followers count (custom Mastodon instance)',
+    '/mastodon/follow/1/pleroma.site': 'followers count (custom Pleroma instance)',
+  },
+  handlers: {
+    '/mastodon/follow/:userId/:instance?': handler
+  }
+})
+
+async function handler ({ userId, instance = 'mastodon.social' }: PathArgs) {
+  const prefixUrl = `https://${instance}/api/v1/`
+  const info = await got(`accounts/${userId}`, { prefixUrl }).json<any>()
+
+  return {
+    subject: `follow @${info.username}@${instance}`,
+    status: millify(info.followers_count),
+    color: '3487CE'
+  }
+}

--- a/api/mastodon.ts
+++ b/api/mastodon.ts
@@ -5,9 +5,9 @@ import { createBadgenHandler, PathArgs } from '../libs/create-badgen-handler'
 export default createBadgenHandler({
   title: 'Mastodon/Pleroma',
   examples: {
-    '/mastodon/follow/1': 'followers count (mastodon.social)',
-    '/mastodon/follow/1/mas.to': 'followers count (custom Mastodon instance)',
-    '/mastodon/follow/1/pleroma.site': 'followers count (custom Pleroma instance)',
+    '/mastodon/follow/1': 'followers (mastodon.social)',
+    '/mastodon/follow/1/mas.to': 'followers (other Mastodon instance)',
+    '/mastodon/follow/1/pleroma.site': 'followers (Pleroma instance)',
   },
   handlers: {
     '/mastodon/follow/:userId/:instance?': handler

--- a/libs/badge-list.ts
+++ b/libs/badge-list.ts
@@ -51,6 +51,7 @@ export const liveBadgeList = [
   'opencollective',
   'keybase',
   'twitter',
+  'mastodon',
   'tidelift',
   'runkit',
   'https',


### PR DESCRIPTION
Fetch followers for a given user from the default (mastodon.social) or custom Mastodon/Pleroma instance.

This adds a new handler:
```
/mastodon/follow/:userId/:instance?
```

## Preview

![image](https://user-images.githubusercontent.com/1170440/82466938-4ed26b80-9ac1-11ea-9690-420666d599cb.png)

As proposed here: https://github.com/badgen/badgen.net/issues/362#issuecomment-615880134