### PR TITLE
feat: allow customn npm and github endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,17 @@ Badgen use [Sentry](https://sentry.io) to collect errors for improving service, 
 
 Badgen do not collect any identifying information.
 
+## Environments
+
+Supported environment variables for managing a Badgen instance.
+
+- `GITHUB_TOKENS` - Comma delimited list of Github Tokens. Required for Github Badges
+- `GITHUB_API` - Custom Github API endpoint. e.g., `https://github.mycompany.com/api/v3`
+- `GITHUB_API_GRAPHQL` - Custom Github GraphQL API endpoint. e.g., `https://github.mycompany.com/api/graphql`
+- `NPM_REGISTRY` - Custom NPM registry endpoint
+- `SENTRY_DSN` - Sentry Error Monitoring Data Source Name
+- `TRACKING_GA` - Google Analytics Tracking ID
+
 ## Contributors
 
 Thanks to our [contributors][contributors-href] 🎉👏

--- a/api/npm.ts
+++ b/api/npm.ts
@@ -69,7 +69,8 @@ async function handler ({ topic, scope, pkg, tag }: PathArgs) {
 
 async function npmMetadata (pkg: string, ver = 'latest'): Promise<any> {
   // only works for ver === 'latest', none-scoped package
-  const endpoint = `https://registry.npmjs.org/${pkg}/${ver}`
+  const host = process.env.NPM_URL || 'https://registry.npmjs.org'
+  const endpoint = `${host}/${pkg}/${ver}`
   return got(endpoint).json<any>()
 }
 
@@ -80,7 +81,8 @@ async function pkgJson (pkg: string, tag = 'latest'): Promise<any> {
 }
 
 async function info (topic: string, pkg: string, tag = 'latest') {
-  const meta = await (tag === 'latest' && pkg[0] !== '@' ? npmMetadata(pkg) : pkgJson(pkg, tag))
+  // when a custom registry is defined, tag=latest or package is scoped use npmMetadata
+  const meta = await (process.env.NPM_URL || (tag === 'latest' && pkg[0] !== '@') ? npmMetadata(pkg) : pkgJson(pkg, tag))
 
   switch (topic) {
     case 'version': {

--- a/api/npm.ts
+++ b/api/npm.ts
@@ -69,17 +69,15 @@ async function handler ({ topic, scope, pkg, tag }: PathArgs) {
 
 async function npmMetadata (pkg: string, ver = 'latest'): Promise<any> {
   const host = process.env.NPM_REGISTRY || "https://registry.npmjs.org"
-  if (pkg[0] === "@") {
+  if (pkg[0] === "@" || ver !== 'latest') {
     const meta = await got(`${host}/${pkg}`).json<any>()
     if (meta["dist-tags"][ver]) {
       return meta.versions[meta["dist-tags"][ver]]
-    } else {
-      throw new BadgenError({ status: '404', color: 'grey', code: 404 })
     }
-  } else {
-    const endpoint = `${host}/${pkg}/${ver}`
-    return got(endpoint).json<any>()
+    throw new BadgenError({ status: '404', color: 'grey', code: 404 })
   }
+  const endpoint = `${host}/${pkg}/${ver}`
+  return got(endpoint).json<any>()
   
 }
 

--- a/api/npm.ts
+++ b/api/npm.ts
@@ -1,7 +1,7 @@
 import cheerio from 'cheerio'
 import got from '../libs/got'
 import { millify, version, versionColor } from '../libs/utils'
-import { createBadgenHandler, PathArgs } from '../libs/create-badgen-handler'
+import { createBadgenHandler, PathArgs, BadgenError } from '../libs/create-badgen-handler'
 
 // https://github.com/npm/registry/blob/master/docs/REGISTRY-API.md
 // https://github.com/npm/registry/blob/master/docs/download-counts.md
@@ -68,10 +68,19 @@ async function handler ({ topic, scope, pkg, tag }: PathArgs) {
 }
 
 async function npmMetadata (pkg: string, ver = 'latest'): Promise<any> {
-  // only works for ver === 'latest', none-scoped package
-  const host = process.env.NPM_URL || 'https://registry.npmjs.org'
-  const endpoint = `${host}/${pkg}/${ver}`
-  return got(endpoint).json<any>()
+  const host = process.env.NPM_REGISTRY || "https://registry.npmjs.org"
+  if (pkg[0] === "@") {
+    const meta = await got(`${host}/${pkg}`).json<any>()
+    if (meta["dist-tags"][ver]) {
+      return meta.versions[meta["dist-tags"][ver]]
+    } else {
+      throw new BadgenError({ status: '404', color: 'grey', code: 404 })
+    }
+  } else {
+    const endpoint = `${host}/${pkg}/${ver}`
+    return got(endpoint).json<any>()
+  }
+  
 }
 
 async function pkgJson (pkg: string, tag = 'latest'): Promise<any> {
@@ -81,8 +90,13 @@ async function pkgJson (pkg: string, tag = 'latest'): Promise<any> {
 }
 
 async function info (topic: string, pkg: string, tag = 'latest') {
-  // when a custom registry is defined, tag=latest or package is scoped use npmMetadata
-  const meta = await (process.env.NPM_URL || (tag === 'latest' && pkg[0] !== '@') ? npmMetadata(pkg) : pkgJson(pkg, tag))
+  // ver === 'latest', non-scoped package use npmMetadata (npm), all others use unpkg
+  // optionally disable unpkg to request all info from NPM
+  const meta = await(
+    process.env.DISABLE_UNPKG === 'true' || (tag === "latest" && pkg[0] !== "@")
+      ? npmMetadata(pkg, tag)
+      : pkgJson(pkg, tag)
+  )
 
   switch (topic) {
     case 'version': {

--- a/libs/github.ts
+++ b/libs/github.ts
@@ -9,7 +9,7 @@ export function restGithub<T = any>(path: string, preview = 'hellcat') {
     authorization: `token ${pickGithubToken()}`,
     accept: `application/vnd.github.${preview}-preview+json`
   }
-  const prefixUrl = process.env.GITHUB_API || "https://api.github.com/"
+  const prefixUrl = process.env.GITHUB_API || 'https://api.github.com/'
   return got.get(path, { prefixUrl, headers }).json<T>()
 }
 
@@ -21,15 +21,16 @@ export function queryGithub<T = any>(query) {
   }
   const json = { query }
   const endpoint =
-    process.env.GITHUB_API_GRAPHQL || "https://api.github.com/graphql"
+    process.env.GITHUB_API_GRAPHQL || 'https://api.github.com/graphql'
   return got.post(endpoint, { json, headers }).json<T>()
 }
 
 function pickGithubToken() {
-  const { GH_TOKENS } = process.env
-  if (!GH_TOKENS) {
+  const { GH_TOKENS, GITHUB_TOKENS } = process.env
+  const githubTokens = GITHUB_TOKENS || GH_TOKENS
+  if (!githubTokens) {
     throw new BadgenError({ status: 'token required' })
   }
-  const tokens = GH_TOKENS.split(',').map(segment => segment.trim())
+  const tokens = githubTokens.split(',').map(segment => segment.trim())
   return rand(tokens)
 }

--- a/libs/github.ts
+++ b/libs/github.ts
@@ -9,7 +9,7 @@ export function restGithub<T = any>(path: string, preview = 'hellcat') {
     authorization: `token ${pickGithubToken()}`,
     accept: `application/vnd.github.${preview}-preview+json`
   }
-  const prefixUrl = 'https://api.github.com/'
+  const prefixUrl = process.env.GITHUB_URL || 'https://api.github.com/'
   return got.get(path, { prefixUrl, headers }).json<T>()
 }
 
@@ -20,7 +20,8 @@ export function queryGithub<T = any>(query) {
     accept: 'application/vnd.github.hawkgirl-preview+json'
   }
   const json = { query }
-  return got.post('https://api.github.com/graphql', { json, headers }).json<T>()
+  const endpoint = process.env.GITHUB_URL_GRAPHQL || 'https://api.github.com/graphql'
+  return got.post(endpoint, { json, headers }).json<T>()
 }
 
 function pickGithubToken() {

--- a/libs/github.ts
+++ b/libs/github.ts
@@ -9,7 +9,7 @@ export function restGithub<T = any>(path: string, preview = 'hellcat') {
     authorization: `token ${pickGithubToken()}`,
     accept: `application/vnd.github.${preview}-preview+json`
   }
-  const prefixUrl = process.env.GITHUB_URL || 'https://api.github.com/'
+  const prefixUrl = process.env.GITHUB_API || "https://api.github.com/"
   return got.get(path, { prefixUrl, headers }).json<T>()
 }
 
@@ -20,7 +20,8 @@ export function queryGithub<T = any>(query) {
     accept: 'application/vnd.github.hawkgirl-preview+json'
   }
   const json = { query }
-  const endpoint = process.env.GITHUB_URL_GRAPHQL || 'https://api.github.com/graphql'
+  const endpoint =
+    process.env.GITHUB_API_GRAPHQL || "https://api.github.com/graphql"
   return got.post(endpoint, { json, headers }).json<T>()
 }
 


### PR DESCRIPTION
- Allow specifying of custom endpoints for NPM and Github. This is to allow usage in a self-hosted enterprise environment.
- Support querying NPM for all package info (scoped + non latest tags). Support abbreviated metadata queries for a bit better performance.
- Support to disable use of unpkg for package lookups (for selfhosted/private NPM use) when `NPM_REGISTRY` is defined.
- Added info on all supported environment variables.

Note:

My custom registry does not support abbreviated NPM metadata unfortunately, so some large internal packages can still time-out. Trying to think of a solution for this.

Maybe either configurable request timeout? Or perhaps an internal node cache (even if it is somewhat short, a minute or two) to avoid undue load on the registry? -- Or both. Open to suggestions, could be another PR.