### PR TITLE
PR for adding some badges for Gitlab

### DIFF
--- a/api/gitlab.ts
+++ b/api/gitlab.ts
@@ -245,11 +245,7 @@ const makeRestCall = async ({ topic, owner, repo, ...restArgs }) => {
     'license': `/projects/${encodeURIComponent(`${owner}/${repo}`)}?license=true`,
   }
 
-  let restPath
-  switch (topic) {
-    default:
-      restPath = restPaths[topic]
-  }
+  let restPath = restPaths[topic]
 
   return restGitlab(restPath, fullResponsePaths.includes(topic))
 }

--- a/api/gitlab.ts
+++ b/api/gitlab.ts
@@ -1,6 +1,5 @@
 import millify from 'millify'
 import distanceToNow from 'date-fns/formatDistanceToNow'
-import got from '../libs/got'
 import { createBadgenHandler, PathArgs } from '../libs/create-badgen-handler'
 import { queryGitlab, restGitlab } from '../libs/gitlab'
 import { version } from '../libs/utils'
@@ -10,12 +9,30 @@ const removeNoSignFromHexColor = (hexColor: string) => hexColor.replace('#', '')
 export default createBadgenHandler({
   title: 'Gitlab',
   examples: {
-    '/gitlab/stars/fdroid/fdroidclient': 'stars (library)',
-    // '/docker/stars/library/ubuntu': 'stars (library)',
-    // '/docker/size/library/ubuntu': 'size (library)',
-    // '/docker/pulls/amio/node-chrome': 'pulls (scoped)',
-    // '/docker/stars/library/mongo?icon=docker&label=stars': 'stars (icon & label)',
-    // '/docker/size/lukechilds/bitcoind/latest/amd64': 'size (scoped/tag/architecture)',
+    '/gitlab/stars/fdroid/fdroidclient': 'stars',
+    '/gitlab/forks/inkscape/inkscape': 'forks',
+    '/gitlab/issues/gitlab-org/gitlab-runner': 'issues',
+    '/gitlab/open-issues/gitlab-org/gitlab-runner': 'issues',
+    '/gitlab/closed-issues/gitlab-org/gitlab-runner': 'issues',
+    '/gitlab/label-issues/NickBusey/HomelabOS/Bug': 'issues by label',
+    '/gitlab/label-issues/NickBusey/HomelabOS/Enhancement/opened': 'open issues by label',
+    '/gitlab/label-issues/NickBusey/HomelabOS/Help%20wanted/closed': 'closed issues by label',
+    '/gitlab/mrs/edouardklein/falsisign': 'MRs',
+    '/gitlab/open-mrs/edouardklein/falsisign': 'open MRs',
+    '/gitlab/closed-mrs/edouardklein/falsisign': 'closed MRs',
+    '/gitlab/merged-mrs/edouardklein/falsisign': 'merged MRs',
+    '/gitlab/branches/gitlab-org%2fgitter/webapp': 'branches',
+    '/gitlab/releases/AuroraOSS/AuroraStore': 'release',
+    '/gitlab/release/veloren/veloren': 'latest release',
+    '/gitlab/tags/commento/commento': 'tags',
+    '/gitlab/contributors/graphviz/graphviz': 'contributors',
+    '/gitlab/license/gitlab-org/omnibus-gitlab': 'license',
+    '/gitlab/commits/cryptsetup/cryptsetup': 'commits count',
+    '/gitlab/commits/cryptsetup/cryptsetup/coverity_scan': 'commits count (branch ref)',
+    '/gitlab/commits/cryptsetup/cryptsetup/v2.2.2': 'commits count (tag ref)',
+    '/gitlab/last-commit/gitlab-org/gitlab-development-kit': 'last commit',
+    '/gitlab/last-commit/gitlab-org/gitlab-development-kit/updating-chromedriver-install-v2': 'last commit (branch ref)',
+    '/gitlab/last-commit/gitlab-org/gitlab-development-kit/v0.2.5': 'last commit (tag ref)',
   },
   handlers: {
     '/gitlab/:topic<stars|forks|issues|open-issues|closed-issues>/:owner/:repo': queryHandler,
@@ -123,10 +140,7 @@ async function restHandler({ topic, owner, repo, ...restArgs }: PathArgs) {
 
 
 async function queryHandler({ topic, owner, repo, ...restArgs }: PathArgs) {
-  console.log(topic, owner, repo)
-
   const result = await makeQueryCall({ topic, owner, repo, ...restArgs })
-  console.log(result)
 
   if (!result) {
     return {
@@ -135,8 +149,6 @@ async function queryHandler({ topic, owner, repo, ...restArgs }: PathArgs) {
       color: 'grey'
     }
   }
-
-  console.log(result)
 
   switch (topic) {
     case 'stars':
@@ -161,13 +173,13 @@ async function queryHandler({ topic, owner, repo, ...restArgs }: PathArgs) {
       return {
         subject: 'open issues',
         status: millify(result.openIssuesCount),
-        color: 'orange'
+        color: result.openIssuesCount === 0 ? 'green' : 'orange'
       }
     case 'closed-issues':
       return {
         subject: 'closed issues',
         status: millify(result.issues.count),
-        color: 'orange'
+        color: 'blue'
       }
     case 'label-issues':
       return {
@@ -214,8 +226,6 @@ const makeQueryCall = async ({ topic, owner, repo, ...restArgs }) => {
     }
   }
 `
-
-  console.log(query)
   return queryGitlab(query).then(res => res.data!.project)
 }
 
@@ -241,9 +251,19 @@ const makeRestCall = async ({ topic, owner, repo, ...restArgs }) => {
       restPath = restPaths[topic]
   }
 
-  console.log("wow", restPath)
   return restGitlab(restPath, fullResponsePaths.includes(topic))
 }
 
-const fullResponsePaths = ['mrs', 'open-mrs', 'closed-mrs', 'merged-mrs', 'commits', 'branches', 'releases', 'tags', 'contributors']
+const fullResponsePaths =
+  [
+    'mrs',
+    'open-mrs',
+    'closed-mrs',
+    'merged-mrs',
+    'commits',
+    'branches',
+    'releases',
+    'tags',
+    'contributors'
+  ]
 

--- a/api/gitlab.ts
+++ b/api/gitlab.ts
@@ -1,0 +1,249 @@
+import millify from 'millify'
+import distanceToNow from 'date-fns/formatDistanceToNow'
+import got from '../libs/got'
+import { createBadgenHandler, PathArgs } from '../libs/create-badgen-handler'
+import { queryGitlab, restGitlab } from '../libs/gitlab'
+import { version } from '../libs/utils'
+
+const removeNoSignFromHexColor = (hexColor: string) => hexColor.replace('#', '')
+
+export default createBadgenHandler({
+  title: 'Gitlab',
+  examples: {
+    '/gitlab/stars/fdroid/fdroidclient': 'stars (library)',
+    // '/docker/stars/library/ubuntu': 'stars (library)',
+    // '/docker/size/library/ubuntu': 'size (library)',
+    // '/docker/pulls/amio/node-chrome': 'pulls (scoped)',
+    // '/docker/stars/library/mongo?icon=docker&label=stars': 'stars (icon & label)',
+    // '/docker/size/lukechilds/bitcoind/latest/amd64': 'size (scoped/tag/architecture)',
+  },
+  handlers: {
+    '/gitlab/:topic<stars|forks|issues|open-issues|closed-issues>/:owner/:repo': queryHandler,
+    '/gitlab/:topic<mrs|open-mrs|closed-mrs|merged-mrs|branches|releases|release|tags|license|contributors>/:owner/:repo': restHandler,
+    '/gitlab/:topic<label-issues>/:owner/:repo/:label/:state?<open|closed>': queryHandler,
+    '/gitlab/:topic<commits|last-commit>/:owner/:repo/:ref?': restHandler,
+  },
+})
+
+
+async function restHandler({ topic, owner, repo, ...restArgs }: PathArgs) {
+  const result = await makeRestCall({ topic, owner, repo, ...restArgs })
+
+  switch (topic) {
+    case 'mrs':
+      return {
+        subject: 'MRs',
+        status: millify(parseInt(result.headers['x-total'])),
+        color: 'blue'
+      }
+    case 'closed-mrs':
+      return {
+        subject: 'closed MRs',
+        status: millify(parseInt(result.headers['x-total'])),
+        color: 'blue'
+      }
+    case 'open-mrs':
+      return {
+        subject: 'open MRs',
+        status: millify(parseInt(result.headers['x-total'])),
+        color: 'blue'
+      }
+    case 'merged-mrs':
+      return {
+        subject: 'merged MRs',
+        status: millify(parseInt(result.headers['x-total'])),
+        color: 'blue'
+      }
+    case 'commits':
+      return {
+        subject: 'commits',
+        status: millify(parseInt(result.headers['x-total'])),
+        color: 'blue'
+      }
+    case 'last-commit':
+      const lastDate = result.length && new Date(result[0].committed_date)
+      const fromNow = lastDate && distanceToNow(lastDate, { addSuffix: true })
+      return {
+        subject: 'last commit',
+        status: fromNow || 'none',
+        color: 'green'
+      }
+    case 'branches':
+      return {
+        subject: 'branches',
+        status: millify(parseInt(result.headers['x-total'])),
+        color: 'blue'
+      }
+    case 'releases':
+      return {
+        subject: 'releases',
+        status: millify(parseInt(result.headers['x-total'])),
+        color: 'blue'
+      }
+    case 'release':
+      const [latest] = result
+      if (!latest) {
+        return {
+          subject: 'release',
+          status: 'none',
+          color: 'yellow'
+        }
+      }
+      return {
+        subject: 'release',
+        status: version(latest.name || latest.tag_name),
+        color: 'blue'
+      }
+    case 'tags':
+      return {
+        subject: 'tags',
+        status: millify(parseInt(result.headers['x-total'])),
+        color: 'blue'
+      }
+    case 'contributors':
+      return {
+        subject: 'contributors',
+        status: millify(parseInt(result.headers['x-total'])),
+        color: 'blue'
+      }
+    case 'license':
+      return {
+        subject: 'license',
+        status: result.license?.name || "no license",
+        color: result.license ? 'blue' : 'grey'
+      }
+    default:
+      return {
+        subject: 'gitlab',
+        status: 'unknown topic',
+        color: 'grey'
+      }
+  }
+}
+
+
+async function queryHandler({ topic, owner, repo, ...restArgs }: PathArgs) {
+  console.log(topic, owner, repo)
+
+  const result = await makeQueryCall({ topic, owner, repo, ...restArgs })
+  console.log(result)
+
+  if (!result) {
+    return {
+      subject: 'gitlab',
+      status: 'not found',
+      color: 'grey'
+    }
+  }
+
+  console.log(result)
+
+  switch (topic) {
+    case 'stars':
+      return {
+        subject: topic,
+        status: millify(result.starCount),
+        color: 'blue'
+      }
+    case 'forks':
+      return {
+        subject: topic,
+        status: millify(result.forksCount),
+        color: 'blue'
+      }
+    case 'issues':
+      return {
+        subject: topic,
+        status: millify(result.issues.count),
+        color: 'blue'
+      }
+    case 'open-issues':
+      return {
+        subject: 'open issues',
+        status: millify(result.openIssuesCount),
+        color: 'orange'
+      }
+    case 'closed-issues':
+      return {
+        subject: 'closed issues',
+        status: millify(result.issues.count),
+        color: 'orange'
+      }
+    case 'label-issues':
+      return {
+        subject: `${restArgs.label}`,
+        status: result.label ? millify(result.issues.count) : '0',
+        color: result.label ? removeNoSignFromHexColor(result.label.color) : 'gray'
+      }
+    default:
+      return {
+        subject: 'gitlab',
+        status: 'unknown topic',
+        color: 'grey'
+      }
+  }
+}
+
+const makeQueryCall = async ({ topic, owner, repo, ...restArgs }) => {
+  const repoQueryBodies = {
+    'stars': 'starCount',
+    'forks': 'forksCount',
+    'open-issues': 'openIssuesCount',
+    'closed-issues': 'issues(state:closed){ count }',
+    'issues': 'issues{ count }',
+  }
+
+  let queryBody
+  switch (topic) {
+    case 'label-issues':
+      const { label, state } = restArgs
+      const stateFilter = state ? `state:${state.toLowerCase()}` : ''
+      queryBody = `
+      issues(labelName:"${label}", ${stateFilter}) { count }
+      label(title: "${label}"){ color }
+      `
+      break
+    default:
+      queryBody = repoQueryBodies[topic]
+  }
+
+  const query = `
+  query {
+    project(fullPath:"${owner}/${repo}") {
+      ${queryBody}
+    }
+  }
+`
+
+  console.log(query)
+  return queryGitlab(query).then(res => res.data!.project)
+}
+
+const makeRestCall = async ({ topic, owner, repo, ...restArgs }) => {
+  const restPaths = {
+    'mrs': `/projects/${encodeURIComponent(`${owner}/${repo}`)}/merge_requests`,
+    'open-mrs': `/projects/${encodeURIComponent(`${owner}/${repo}`)}/merge_requests?state=opened`,
+    'closed-mrs': `/projects/${encodeURIComponent(`${owner}/${repo}`)}/merge_requests?state=closed`,
+    'merged-mrs': `/projects/${encodeURIComponent(`${owner}/${repo}`)}/merge_requests?state=merged`,
+    'commits': `/projects/${encodeURIComponent(`${owner}/${repo}`)}/repository/commits?${restArgs.ref ? "ref_name=" + restArgs.ref : ''}`,
+    'last-commit': `/projects/${encodeURIComponent(`${owner}/${repo}`)}/repository/commits?${restArgs.ref ? "ref_name=" + restArgs.ref : ''}`,
+    'branches': `/projects/${encodeURIComponent(`${owner}/${repo}`)}/repository/branches`,
+    'tags': `/projects/${encodeURIComponent(`${owner}/${repo}`)}/repository/tags`,
+    'contributors': `/projects/${encodeURIComponent(`${owner}/${repo}`)}/repository/contributors`,
+    'releases': `/projects/${encodeURIComponent(`${owner}/${repo}`)}/releases`,
+    'release': `/projects/${encodeURIComponent(`${owner}/${repo}`)}/releases`,
+    'license': `/projects/${encodeURIComponent(`${owner}/${repo}`)}?license=true`,
+  }
+
+  let restPath
+  switch (topic) {
+    default:
+      restPath = restPaths[topic]
+  }
+
+  console.log("wow", restPath)
+  return restGitlab(restPath, fullResponsePaths.includes(topic))
+}
+
+const fullResponsePaths = ['mrs', 'open-mrs', 'closed-mrs', 'merged-mrs', 'commits', 'branches', 'releases', 'tags', 'contributors']
+

--- a/libs/badge-list.ts
+++ b/libs/badge-list.ts
@@ -7,6 +7,7 @@ const rel = (...args) => path.resolve(__dirname, ...args)
 export const liveBadgeList = [
   // source control
   'github',
+  'gitlab',
   // release registries
   'npm',
   'david',

--- a/libs/gitlab.ts
+++ b/libs/gitlab.ts
@@ -1,0 +1,33 @@
+import got from './got'
+import { BadgenError } from './create-badgen-handler'
+
+const rand = <T>(arr: T[]): T => arr[Math.floor(Math.random() * arr.length)]
+
+
+// request gitlab api v4 (graphql)
+export function queryGitlab<T = any>(query) {
+  const headers = {
+    authorization: `Bearer ${pickGitlabToken()}`,
+  }
+  const json = { query }
+  const endpoint =
+    process.env.GITLAB_API_GRAPHQL || 'https://gitlab.com/api/graphql'
+  return got.post(endpoint, { json, headers }).json<T>()
+}
+
+export function restGitlab<T = any>(path: string, fullResponse = false) {
+  const headers = {
+    authorization: `Bearer ${pickGitlabToken()}`,
+  }
+  const prefixUrl = process.env.GITLAB_API || 'https://gitlab.com/api/v4'
+  return fullResponse ? got.get(path, { prefixUrl, headers }) : got.get(path, { prefixUrl, headers }).json<T>()
+}
+
+function pickGitlabToken() {
+  const { GITLAB_TOKENS = 'yB_tPPg9V2rNsB1URT4J' } = process.env
+  if (!GITLAB_TOKENS) {
+    throw new BadgenError({ status: 'token late required' })
+  }
+  const tokens = GITLAB_TOKENS.split(',').map(segment => segment.trim())
+  return rand(tokens)
+}

--- a/libs/gitlab.ts
+++ b/libs/gitlab.ts
@@ -26,7 +26,7 @@ export function restGitlab<T = any>(path: string, fullResponse = false) {
 function pickGitlabToken() {
   const { GITLAB_TOKENS } = process.env
   if (!GITLAB_TOKENS) {
-    throw new BadgenError({ status: 'token late required' })
+    throw new BadgenError({ status: 'token required' })
   }
   const tokens = GITLAB_TOKENS.split(',').map(segment => segment.trim())
   return rand(tokens)

--- a/libs/gitlab.ts
+++ b/libs/gitlab.ts
@@ -24,7 +24,7 @@ export function restGitlab<T = any>(path: string, fullResponse = false) {
 }
 
 function pickGitlabToken() {
-  const { GITLAB_TOKENS = 'yB_tPPg9V2rNsB1URT4J' } = process.env
+  const { GITLAB_TOKENS } = process.env
   if (!GITLAB_TOKENS) {
     throw new BadgenError({ status: 'token late required' })
   }

--- a/now.json
+++ b/now.json
@@ -13,6 +13,7 @@
   "env": {
     "GH_TOKENS": "@badgen-gh-tokens",
     "SENTRY_DSN": "@badgen-sentry-dsn",
-    "TRACKING_GA": "@badgen-tracking-ga"
+    "TRACKING_GA": "@badgen-tracking-ga",
+    "GITLAB_TOKENS": "@badgen-gl-tokens"
   }
 }


### PR DESCRIPTION
fixes #297 

I've added the following badges for Gitlab.

![Screen Shot 2020-08-15 at 5 08 22 PM](https://user-images.githubusercontent.com/25799714/90314529-1ce47000-df1d-11ea-9200-321dfa100bbf.png)

I've covered some of them, but their API and documentation beat me many times 😆  (especially since I am not familiar with GraphQL or complex Gitlab project flows with lots of Jobs, tags and other things). Any suggestion and/or request for changing something is welcome 😄 


❗ When deploying the next time with this fix (if merged, of course) there is needed to add a new env variable named `GITLAB_TOKENS`(can be a list, same as GITHUB_TOKENS).  It should have `read_api` scope