### PR TITLE
Add badges for Liberapay

### DIFF
--- a/api/liberapay.ts
+++ b/api/liberapay.ts
@@ -1,0 +1,65 @@
+import got from '../libs/got'
+import { createBadgenHandler, PathArgs } from '../libs/create-badgen-handler'
+
+export default createBadgenHandler({
+  title: 'Liberapay',
+  examples: {
+    '/liberapay/gives/aurelienpierre': 'giving',
+    '/liberapay/receives/GIMP': 'receiving',
+    '/liberapay/patrons/microG': 'patrons count',
+    '/liberapay/goal/Changaco': 'goal progress',
+  },
+  handlers: {
+    '/liberapay/:topic<gives|receives|patrons|goal>/:slug': handler
+  }
+})
+
+// https://github.com/badges/shields/blob/master/services/liberapay
+
+async function handler ({ topic, slug }: PathArgs) {
+  const endpoint = `https://liberapay.com/${slug}/public.json`
+
+  const details = await got(endpoint).json<any>()
+  const receivingLocaleOptions = {
+    style: 'currency',
+    currency: details.giving.currency
+  }
+  const givingLocaleOptions = {
+    style: 'currency',
+    currency: details.receiving.currency
+  }
+
+  let goal = 'not set'
+  if (details.goal) {
+    const goalAmount = parseFloat(details.goal.amount)
+    const receivesAmount = parseFloat(details.receiving.amount)
+    goal = `${Math.round((receivesAmount / goalAmount) * 100)}%`
+  }
+
+  switch (topic) {
+    case 'gives':
+      return {
+        subject: 'gives',
+        status: `${parseFloat(details.giving.amount).toLocaleString('en-US', givingLocaleOptions)}/week`,
+        color: 'yellow'
+      }
+    case 'receives':
+      return {
+        subject: 'receives',
+        status: `${parseFloat(details.receiving.amount).toLocaleString('en-US', receivingLocaleOptions)}/week`,
+        color: 'yellow'
+      }
+    case 'patrons':
+      return {
+        subject: 'patrons',
+        status: details.npatrons,
+        color: 'yellow'
+      }
+    case 'goal':
+      return {
+        subject: 'goal progress',
+        status: goal,
+        color: goal !== 'not set' ? 'yellow' : 'grey'
+      }
+  }
+}

--- a/libs/badge-list.ts
+++ b/libs/badge-list.ts
@@ -60,6 +60,7 @@ export const liveBadgeList = [
   'runkit',
   'https',
   'jenkins',
+  'liberapay'
 ]
 
 export async function loadBadgeMeta () {


### PR DESCRIPTION
Analogous to [Shields.io](https://shields.io/category/funding), this PR adds the following badges to showcase Liberapay stats:

- donations given (amount per week)
- donations received (amount per week)
- patrons (aka supporters) (amount)
- goal progress (percents)

Here is what it looks like:
<img width="941" alt="Screenshot" src="https://user-images.githubusercontent.com/6566248/90870788-63612100-e39a-11ea-927e-3a7cbb6428f4.png">

P. S. I have used the OpenCollective file as a template