### PR TITLE
Bundlephobia: dependency-count and tree-shaking badges

### DIFF
--- a/api/bundlephobia.ts
+++ b/api/bundlephobia.ts
@@ -59,7 +59,7 @@ async function handler ({ topic, scope, name }: PathArgs) {
       }
     case 'tree-shaking':
       return {
-        subject: 'tree-shaking',
+        subject: 'tree shaking',
         status: isTreeShakeable ? 'supported' : 'not supported',
         color: isTreeShakeable ? 'green' : 'red'
       }

--- a/api/bundlephobia.ts
+++ b/api/bundlephobia.ts
@@ -32,7 +32,11 @@ async function handler ({ topic, scope, name }: PathArgs) {
     }
   }
 
-  const { size, gzip, dependencyCount, hasSideEffects } = resp
+  const { size, gzip, dependencyCount, hasJSModule, hasJSNext } = resp
+
+  // Tree-shaking detection condition is copied from bundlephobia.com website. See:
+  // https://github.com/pastelsky/bundlephobia/blob/bundlephobia/pages/result/ResultPage.js
+  const isTreeShakeable = hasJSModule || hasJSNext
 
   switch (topic) {
     case 'min':
@@ -56,8 +60,8 @@ async function handler ({ topic, scope, name }: PathArgs) {
     case 'tree-shaking':
       return {
         subject: 'tree-shaking',
-        status: hasSideEffects ? 'not supported' : 'supported',
-        color: hasSideEffects ? 'red' : 'green'
+        status: isTreeShakeable ? 'supported' : 'not supported',
+        color: isTreeShakeable ? 'green' : 'red'
       }
     default:
       return {

--- a/api/bundlephobia.ts
+++ b/api/bundlephobia.ts
@@ -49,7 +49,7 @@ async function handler ({ topic, scope, name }: PathArgs) {
       }
     case 'dependency-count':
       return {
-        subject: 'dependency-count',
+        subject: 'dependency count',
         status: dependencyCount,
         color: 'blue'
       }

--- a/api/bundlephobia.ts
+++ b/api/bundlephobia.ts
@@ -8,6 +8,8 @@ export default createBadgenHandler({
     '/bundlephobia/min/react': 'minified',
     '/bundlephobia/minzip/react': 'minified + gzip',
     '/bundlephobia/minzip/@material-ui/core': '(scoped pkg) minified + gzip',
+    '/bundlephobia/dependency-count/react': 'dependency count',
+    '/bundlephobia/tree-shaking/react-colorful': 'tree-shaking support',
   },
   handlers: {
     '/bundlephobia/:topic/:scope<@.*>/:name': handler,
@@ -30,7 +32,7 @@ async function handler ({ topic, scope, name }: PathArgs) {
     }
   }
 
-  const { size, gzip } = resp
+  const { size, gzip, dependencyCount, hasSideEffects } = resp
 
   switch (topic) {
     case 'min':
@@ -44,6 +46,18 @@ async function handler ({ topic, scope, name }: PathArgs) {
         subject: 'minzipped size',
         status: byteSize(gzip, { units: 'iec' }).toString().replace(/iB\b/, 'B'),
         color: 'blue'
+      }
+    case 'dependency-count':
+      return {
+        subject: 'dependency-count',
+        status: dependencyCount,
+        color: 'blue'
+      }
+    case 'tree-shaking':
+      return {
+        subject: 'tree-shaking',
+        status: hasSideEffects ? 'not supported' : 'supported',
+        color: hasSideEffects ? 'red' : 'green'
       }
     default:
       return {


### PR DESCRIPTION
Hi! Love your project and use it quite often.

My hobby is creating tiny libraries and I know many people who need badges to promote that their JS-libraries have no dependencies (or have few of them). Also tagging a project as side-effect-free/tree-shakable would be very helpful for developers.

Example: https://github.com/pastelsky/bundlephobia/issues/224

So I decided to create a small PR to add these badges.
They get data from the bundlephobia's API that you already use, so it's actually not a big deal.
![image](https://user-images.githubusercontent.com/206567/92334588-2a15fa00-f098-11ea-99d2-9d1d1f5bb911.png)
