### PR TITLE
fix(chrome-web-store): bump api version (fix #431)

### DIFF
--- a/api/chrome-web-store.ts
+++ b/api/chrome-web-store.ts
@@ -19,7 +19,8 @@ export default createBadgenHandler({
 })
 
 async function handler ({ topic, id }: PathArgs) {
-  const meta = await webstore.detail({ id })
+  const apiVersion = '20200914'
+  const meta = await webstore.detail({ id, version: apiVersion })
   switch (topic) {
     case 'v':
       return {


### PR DESCRIPTION
version number bumped according to the check https://github.com/badgen/badgen.net/runs/1219336506?check_suite_focus=true