### PR TITLE
chore: remove dependabot from badge list

### DIFF
--- a/libs/badge-list.ts
+++ b/libs/badge-list.ts
@@ -50,17 +50,16 @@ export const liveBadgeList = [
   'xo',
   'badgesize',
   'jsdelivr',
-  'dependabot',
   // utilities
   'opencollective',
   'keybase',
   'twitter',
   'mastodon',
   'tidelift',
+  'jenkins',
+  'liberapay',
   'runkit',
   'https',
-  'jenkins',
-  'liberapay'
 ]
 
 export async function loadBadgeMeta () {


### PR DESCRIPTION
Now the recommended way is [GitHub badge](https://badgen.net/github/#github-dependabot-owner-repo)