### PR TITLE
feat(docker): Add image layers handler

### DIFF
--- a/api/docker.ts
+++ b/api/docker.ts
@@ -1,5 +1,6 @@
 import millify from 'millify'
 import got from '../libs/got'
+import { getDockerAuthToken, getDockerFatManifest, getDockerImageManifest } from '../libs/docker'
 import { createBadgenHandler, PathArgs } from '../libs/create-badgen-handler'
 
 export default createBadgenHandler({
@@ -12,10 +13,12 @@ export default createBadgenHandler({
     '/docker/stars/library/mongo?icon=docker&label=stars': 'stars (icon & label)',
     '/docker/size/lukechilds/bitcoind/latest/amd64': 'size (scoped/tag/architecture)',
     '/docker/size/lucashalbert/curl/latest/arm/v6': 'size (scoped/tag/architecture/variant)',
+    '/docker/layers/lucashalbert/curl/latest/arm/v6': 'layers (scoped/tag/architecture/variant)',
   },
   handlers: {
     '/docker/:topic<stars|pulls>/:scope/:name': starPullHandler,
-    '/docker/size/:scope/:name/:tag?/:architecture?/:variant?': sizeHandler
+    '/docker/size/:scope/:name/:tag?/:architecture?/:variant?': sizeHandler,
+    '/docker/layers/:scope/:name/:tag?/:architecture?/:variant?': layersHandler,
   }
 })
 
@@ -99,6 +102,71 @@ async function sizeHandler ({ scope, name, tag, architecture, variant }: PathArg
   return {
     subject: 'docker image size',
     status: `${sizeInMegabytes} MB`,
+    color: 'blue'
+  }
+}
+
+async function layersHandler ({ scope, name, tag, architecture, variant }: PathArgs) {
+  tag = tag ? tag : 'latest'
+  architecture = architecture ? architecture : 'amd64'
+  variant = variant ? variant : ''
+
+  const token = (await getDockerAuthToken(scope, name)).token
+  if (! token) {
+    return {
+      subject: 'docker layers',
+      status: 'unknown image',
+      color: 'grey'
+    }
+  }
+
+  const manifests = (await getDockerFatManifest(scope, name, tag, token)).manifests
+  
+  if (! manifests) {
+    return {
+      subject: 'docker layers',
+      status: 'unknown tag',
+      color: 'grey'
+    }
+  }
+
+  let manifest = manifests.find(manifests => manifests.platform.architecture === architecture)
+
+  if (! manifest) {
+    return {
+      subject: 'docker layers',
+      status: 'unknown architecture',
+      color: 'grey'
+    }
+  }
+
+  if (variant) {
+    manifest = manifests.filter(manifests => manifests.platform.architecture === architecture).find(manifests => manifests.platform.variant === variant)
+
+    if (! manifest) {
+      return {
+        subject: 'docker layers',
+        status: 'unknown variant',
+        color: 'grey'
+      }
+    }
+  }
+
+  const digest = manifest.digest
+
+  const layers = (await getDockerImageManifest(scope, name, digest, token)).layers
+
+  if (! layers) {
+    return {
+      subject: 'docker layers',
+      status: 'error getting layers',
+      color: 'grey'
+    }
+  }
+
+  return {
+    subject: 'docker layers',
+    status: `${layers.length}`,
     color: 'blue'
   }
 }

--- a/api/docker.ts
+++ b/api/docker.ts
@@ -227,7 +227,7 @@ async function layersHandler ({ scope, name, tag, architecture, variant }: PathA
   }
 
   return {
-    subject: `${sizeInMegabytes} MB`,
+    subject: 'docker layers',
     status: `${layers.length}`,
     color: 'blue'
   }

--- a/api/docker.ts
+++ b/api/docker.ts
@@ -1,7 +1,7 @@
 import millify from 'millify'
 import got from '../libs/got'
 import { getDockerAuthToken, getManifestList, getImageManifest, getImageConfig } from '../libs/docker'
-import { createBadgenHandler, PathArgs, BadgenError } from '../libs/create-badgen-handler'
+import { createBadgenHandler, PathArgs } from '../libs/create-badgen-handler'
 
 const help = `## Usage
 
@@ -142,7 +142,11 @@ async function layersHandler ({ scope, name, tag, architecture, variant }: PathA
 
   const layers = image_config.history
   if (! layers) {
-    throw new BadgenError({ status: `error getting layers` })
+    return {
+      subject: 'docker layers',
+      status: 'error getting layers',
+      color: 'grey'
+    }
   }
 
   return {
@@ -167,7 +171,11 @@ async function metadataHandler ({ type, scope, name, tag, architecture, variant 
 
   const metadata = image_config.container_config.Labels[`org.label-schema.${type}`]
   if (! metadata) {
-    throw new BadgenError({ status: `error getting ${type}` })
+    return {
+      subject: 'docker metadata',
+      status: `error getting ${type}`,
+      color: 'grey'
+    }
   }
 
   return {

--- a/libs/docker.ts
+++ b/libs/docker.ts
@@ -1,4 +1,5 @@
 import got from './got'
+import { BadgenError } from './create-badgen-handler'
 
 // request image specific DockerHub pull token
 export function getDockerAuthToken<T = any>(scope: string, name: string) {
@@ -8,11 +9,81 @@ export function getDockerAuthToken<T = any>(scope: string, name: string) {
     service: service,
     scope: `repository:${scope}/${name}:pull`
   }
-  return got.get("token", { prefixUrl, searchParams }).json<T>()
+  
+  const resp = got.get("token", { prefixUrl, searchParams }).json<T>()
+
+  if (! resp) {
+    throw new BadgenError({ status: 'unknown image' })
+  }
+
+  return resp
 }
 
 // query the docker registry api
-export function queryDockerRegistry<T = any>(path: string, headers) {
+function queryDockerRegistry<T = any>(path: string, headers) {
   const prefixUrl = process.env.DOCKER_REGISTRY_API || 'https://registry.hub.docker.com/'
   return got.get(path, { prefixUrl, headers }).json<T>()
+}
+
+// get fat manifest list and return
+export async function getManifestList<T = any>(scope: string, name: string, tag: string, architecture: string, variant: string, token: string) {
+  const headers = {
+    authorization: `Bearer ${token}`,
+    accept: `application/vnd.docker.distribution.manifest.list.v2+json`
+  }
+  const path = `v2/${scope}/${name}/manifests/${tag}`
+  const manifest_list = (await queryDockerRegistry(path, headers)).manifests
+
+  if (! manifest_list) {
+    throw new BadgenError({ status: 'unknown tag' })
+  }
+
+  let manifest = manifest_list.find(manifest_list => manifest_list.platform.architecture === architecture)
+
+  if (! manifest) {
+    throw new BadgenError({ status: 'unknown architecture' })
+  }
+
+  if (variant) {
+    manifest = manifest_list.filter(manifest_list => manifest_list.platform.architecture === architecture).find(manifest_list => manifest_list.platform.variant === variant)
+
+    if (! manifest) {
+      throw new BadgenError({ status: 'unknown variant' })
+    }
+  }
+
+  if (! manifest.digest) {
+    throw new BadgenError({ status: 'image digest error' })
+  }
+
+  return manifest
+}
+
+export async function getImageManifest<T = any>(scope: string, name: string, digest: string, token: string) {
+  const headers = {
+    authorization: `Bearer ${token}`,
+    accept: `application/vnd.docker.distribution.manifest.list.v2+json`
+  }
+  const path = `v2/${scope}/${name}/manifests/${digest}`
+  const image_manifest = await queryDockerRegistry(path, headers)
+
+  if (! image_manifest) {
+    throw new BadgenError({ status: 'image manifest error' })
+  }
+
+  return image_manifest
+}
+
+export async function getImageConfig<T = any>(scope: string, name: string, digest: string, token: string) {
+  const headers = {
+    authorization: `Bearer ${token}`,
+    accept: `application/vnd.docker.image.config+json`
+  }
+  const path = `v2/${scope}/${name}/blobs/${digest}`
+  const image_config = await queryDockerRegistry(path, headers)
+
+  if (! image_config) {
+    throw new BadgenError({ status: 'image config error' })
+  }
+  return image_config
 }

--- a/libs/docker.ts
+++ b/libs/docker.ts
@@ -1,5 +1,4 @@
 import got from './got'
-import { BadgenError } from './create-badgen-handler'
 
 // request image specific DockerHub pull token
 export function getDockerAuthToken<T = any>(scope: string, name: string) {

--- a/libs/docker.ts
+++ b/libs/docker.ts
@@ -1,0 +1,35 @@
+import got from './got'
+import { BadgenError } from './create-badgen-handler'
+
+// request image specific DockerHub pull token
+export function getDockerAuthToken<T = any>(scope: string, name: string) {
+  const prefixUrl = process.env.DOCKER_AUTHENTICATION_API || 'https://auth.docker.io/'
+  const service = 'registry.docker.io'
+  const searchParams = {
+    service: service,
+    scope: `repository:${scope}/${name}:pull`
+  }
+  return got.get("token", { prefixUrl, searchParams }).json<T>()
+}
+
+// request fat manifest
+export function getDockerFatManifest<T = any>(scope: string, name: string, tag: string, token: string) {
+  const headers = {
+    authorization: `Bearer ${token}`,
+    accept: `application/vnd.docker.distribution.manifest.list.v2+json`
+  }
+  const prefixUrl = process.env.DOCKER_REGISTRY_API || 'https://registry.hub.docker.com/'
+  const path = `v2/${scope}/${name}/manifests/${tag}`
+  return got.get(path, { prefixUrl, headers }).json<T>()
+}
+
+// request specific image manifest
+export function getDockerImageManifest<T = any>(scope: string, name: string, digest: string, token: string) {
+  const headers = {
+    authorization: `Bearer ${token}`,
+    accept: `application/vnd.docker.distribution.manifest.v2+json`
+  }
+  const prefixUrl = process.env.DOCKER_REGISTRY_API || 'https://registry.hub.docker.com/'
+  const path = `v2/${scope}/${name}/manifests/${digest}`
+  return got.get(path, { prefixUrl, headers }).json<T>()
+}

--- a/libs/docker.ts
+++ b/libs/docker.ts
@@ -11,24 +11,8 @@ export function getDockerAuthToken<T = any>(scope: string, name: string) {
   return got.get("token", { prefixUrl, searchParams }).json<T>()
 }
 
-// request fat manifest
-export function getDockerFatManifest<T = any>(scope: string, name: string, tag: string, token: string) {
-  const headers = {
-    authorization: `Bearer ${token}`,
-    accept: `application/vnd.docker.distribution.manifest.list.v2+json`
-  }
+// query the docker registry api
+export function queryDockerRegistry<T = any>(path: string, headers) {
   const prefixUrl = process.env.DOCKER_REGISTRY_API || 'https://registry.hub.docker.com/'
-  const path = `v2/${scope}/${name}/manifests/${tag}`
-  return got.get(path, { prefixUrl, headers }).json<T>()
-}
-
-// request specific image manifest
-export function getDockerImageManifest<T = any>(scope: string, name: string, digest: string, token: string) {
-  const headers = {
-    authorization: `Bearer ${token}`,
-    accept: `application/vnd.docker.distribution.manifest.v2+json`
-  }
-  const prefixUrl = process.env.DOCKER_REGISTRY_API || 'https://registry.hub.docker.com/'
-  const path = `v2/${scope}/${name}/manifests/${digest}`
   return got.get(path, { prefixUrl, headers }).json<T>()
 }


### PR DESCRIPTION
This PR facilitates generating architecture variant layer badges such as `arm/v6` VS `arm/v7` VS `arm64/v8`. It fulfills the layer feature requests in issue [#185](https://github.com/badgen/badgen.net/issues/185). Unfortunately, the DockerHub Registry API Scheme v2 does not support `blob` layers, and instead shows `fsLayers` which do not include layers of size 0 (ie: `CMD`, `ENV`, `LABEL`, `ENTRYPOINT`, etc...). For this reason, users will notice a difference in the number of layers between microbadger and badgen.net.

This can be tested using the multi-architecture [lucashalbert/curl:latest](https://hub.docker.com/r/lucashalbert/curl)  dockerhub image like so:

* [https://badgen.net/docker/layers/lucashalbert/curl/latest/arm/v6](https://badgen.net/docker/layers/lucashalbert/curl/latest/arm/v6).
* [https://badgen.net/docker/layers/lucashalbert/curl/latest/arm/v7](https://badgen.net/docker/layers/lucashalbert/curl/latest/arm/v7).
* [https://badgen.net/docker/layers/lucashalbert/curl/latest/arm64/v8](https://badgen.net/docker/layers/lucashalbert/curl/latest/arm64/v8).