### PR TITLE
Add CTAN service

### DIFF
--- a/api/ctan.ts
+++ b/api/ctan.ts
@@ -1,0 +1,41 @@
+import got from '../libs/got'
+import { version, versionColor } from '../libs/utils'
+import { createBadgenHandler, PathArgs } from '../libs/create-badgen-handler'
+
+const CTAN_API_URL = 'https://ctan.org/json/2.0/'
+
+const client = got.extend({ prefixUrl: CTAN_API_URL, timeout: 3500 })
+
+export default createBadgenHandler({
+  title: 'CTAN',
+  examples: {
+    '/ctan/v/latexindent': 'version',
+    '/ctan/license/latexdiff': 'license'
+  },
+  handlers: {
+    '/ctan/:topic<v|license>/:pkg': handler,
+  }
+})
+
+async function handler ({ topic, pkg }: PathArgs) {
+  const {
+    license,
+    version: versionInfo,
+  } = await client.get(`pkg/${pkg}`).json<any>()
+  const { number: ver } = versionInfo;
+
+  switch (topic) {
+    case 'v':
+      return {
+        subject: 'ctan',
+        status: version(ver),
+        color: versionColor(ver)
+      }
+    case 'license':
+      return {
+        subject: 'license',
+        status: license || 'unknown',
+        color: 'green'
+      }
+  }
+}

--- a/libs/badge-list.ts
+++ b/libs/badge-list.ts
@@ -29,6 +29,7 @@ export const liveBadgeList = [
   'cocoapods',
   'haxelib',
   'opam',
+  'ctan',
   'scoop',
   'winget',
   'f-droid',


### PR DESCRIPTION
This adds a new handler:

```
/ctan/:topic/:pkg
```
where the topic can be one of:
- `v` (version)
- `license`

## Preview

![image](https://user-images.githubusercontent.com/1170440/102303845-60e39200-3f5c-11eb-89e3-63c10ea82847.png)
