### PR TITLE
ci: run lint job on all pull requests

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,10 +1,6 @@
 name: lint and build
 
-on:
-  push:
-  pull_request:
-    branches:
-    - '**:**'
+on: pull_request
 
 jobs:
   build:

--- a/api/ctan.ts
+++ b/api/ctan.ts
@@ -22,7 +22,7 @@ async function handler ({ topic, pkg }: PathArgs) {
     license,
     version: versionInfo,
   } = await client.get(`pkg/${pkg}`).json<any>()
-  const { number: ver } = versionInfo;
+  const { number: ver } = versionInfo
 
   switch (topic) {
     case 'v':


### PR DESCRIPTION
The lint job didn't run on pull requests. Changed the trigger to simply on all pull requests.