### PR TITLE
Add Crystal shards service

### DIFF
--- a/api/shards.ts
+++ b/api/shards.ts
@@ -1,0 +1,60 @@
+import got from '../libs/got'
+import { millify, version, versionColor } from '../libs/utils'
+import { createBadgenHandler, PathArgs } from '../libs/create-badgen-handler'
+
+const SHARDS_REPO_URL = 'https://shardbox.org/'
+
+const client = got.extend({ prefixUrl: SHARDS_REPO_URL })
+
+export default createBadgenHandler({
+  title: 'Crystal shards',
+  examples: {
+    '/shards/v/kemal': 'version',
+    '/shards/v/crinja': 'version',
+    '/shards/license/clear': 'license',
+    '/shards/crystal/amber': 'crystal version',
+    '/shards/dependents/lucky': 'dependents'
+  },
+  handlers: {
+    '/shards/:topic<v|license|crystal|dependents>/:shard': handler
+  }
+})
+
+async function handler({ topic, shard }: PathArgs) {
+  const html = await client.get(`shards/${shard}`).text()
+
+  switch (topic) {
+    case 'v':
+      const ver = html.match(/class="version">([^<]+)<\//i)?.[1].trim()
+      return {
+        subject: 'shards',
+        status: version(ver),
+        color: versionColor(ver)
+      }
+    case 'license': {
+      const license = html.match(/opensource.org\/licenses\/[^>]+?>([^<]+)<\//i)?.[1].trim()
+      return {
+        subject: 'license',
+        status: license || 'unknown',
+        color: 'blue'
+      }
+    }
+    case 'crystal': {
+      let ver = html.match(/Crystal<\/span>\s*<span[^>]*?>([^<]+)<\//i)?.[1].trim()
+      if (!ver || ver === 'none') ver = '*'
+      return {
+        subject: 'crystal',
+        status: version(ver),
+        color: 'green'
+      }
+    }
+    case 'dependents': {
+      const dependents = Number(html.match(/Dependents[^>]*? class="count">([^<]+)<\//i)?.[1].trim())
+      return {
+        subject: 'dependents',
+        status: millify(dependents),
+        color: 'green'
+      }
+    }
+  }
+}

--- a/api/shards.ts
+++ b/api/shards.ts
@@ -10,7 +10,6 @@ export default createBadgenHandler({
   title: 'Crystal shards',
   examples: {
     '/shards/v/kemal': 'version',
-    '/shards/v/crinja': 'version',
     '/shards/license/clear': 'license',
     '/shards/crystal/amber': 'crystal version',
     '/shards/dependents/lucky': 'dependents'

--- a/libs/badge-list.ts
+++ b/libs/badge-list.ts
@@ -36,6 +36,7 @@ export const liveBadgeList = [
   'winget',
   'f-droid',
   'pub',
+  'shards',
   // CI
   'travis',
   'circleci',


### PR DESCRIPTION
This adds a new handler powered by scraping https://shardbox.org:

```
/shards/:topic<v|license|crystal|dependents>/:shard
```
where the topic can be one of:
- `v` (version)
- `license`
- `crystal` (Crystal version)
- `dependents` (number of dependents)

## Preview

![image](https://user-images.githubusercontent.com/1170440/103184623-42b15680-48b9-11eb-8136-3362d45b3dc4.png)
