### PR TITLE
Change `@now/node` to `@vercel/node`

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -2,8 +2,8 @@
   "version": 2,
   "regions": ["all"],
   "builds": [
-    { "src": "package.json", "use": "@now/static-build" },
-    { "src": "api/*.ts", "use": "@now/node" }
+    { "src": "package.json", "use": "@vercel/static-build" },
+    { "src": "api/*.ts", "use": "@vercel/node" }
   ],
   "routes": [
     { "src": "/docs/(.*)", "status": 301, "headers": { "Location": "/$1" } },


### PR DESCRIPTION
> "@now/node" is deprecated and will stop receiving updates on December 31, 2020. Please use "@vercel/node" instead.

### Sources
- https://www.npmjs.com/package/@now/node
- https://vercel.com/blog/zeit-is-now-vercel