### PR TITLE
fix: handle "skipped" status in github combined checks (#471)

### DIFF
--- a/api/github.ts
+++ b/api/github.ts
@@ -97,6 +97,7 @@ function combined (states: Array<any>, stateKey: string = 'state') {
 
   const succeeded = states
     .filter(x => x[stateKey] !== 'cancelled')
+    .filter(x => x[stateKey] !== 'skipped')
     .every(x => x[stateKey] === 'success')
 
   if (succeeded) return 'success'


### PR DESCRIPTION
Error log:

```
[GET] /github/checks/contributte/translation
11:04:25:55
2021-01-08T03:04:26.124Z	6abb7984-f2b1-47d6-8c2d-0733ea638f96	ERROR	UCE /github/checks/contributte/translation Unknown states: success,success,success,success,success,success,success,skipped,success,success,success,success,success,success,success,success,skipped,success,success,success,success,success,success,success,success,success,success Error: Unknown states: success,success,success,success,success,success,success,skipped,success,success,success,success,success,success,success,success,skipped,success,success,success,success,success,success,success,success,success,success
    at combined (/vercel/workpath1/api/github.ts:105:9)
    at Object.checks (/vercel/workpath1/api/github.ts:121:13)
    at processTicksAndRejections (internal/process/task_queues.js:97:5)
    at async Promise.all (index 1)
    at badgenHandler (/vercel/workpath1/libs/create-badgen-handler.ts:101:48)
    at Server.<anonymous> (/var/task/___now_helpers.js:813:13)
```
