### PR TITLE
Add Elm package service

### DIFF
--- a/api/elm-package.ts
+++ b/api/elm-package.ts
@@ -1,0 +1,59 @@
+import got from '../libs/got'
+import { version, versionColor } from '../libs/utils'
+import { createBadgenHandler, PathArgs } from '../libs/create-badgen-handler'
+
+const ELM_PACKAGES_REPO_URL = 'https://package.elm-lang.org/'
+
+const client = got.extend({ prefixUrl: ELM_PACKAGES_REPO_URL })
+
+export default createBadgenHandler({
+  title: 'Elm Package',
+  examples: {
+    '/elm-package/v/avh4/elm-color': 'version',
+    '/elm-package/license/mdgriffith/elm-ui': 'license',
+    '/elm-package/elm/justinmimbs/date': 'elm version'
+  },
+  handlers: {
+    '/elm-package/:topic<v|version|license|elm>/:owner/:name': handler
+  }
+})
+
+async function handler ({ topic, owner, name }: PathArgs) {
+  const {
+    'elm-version': elmVersion,
+    license,
+    version: ver
+  } = await client.get(`packages/${owner}/${name}/latest/elm.json`).json()
+
+  switch (topic) {
+    case 'v':
+    case 'version':
+      return {
+        subject: 'version',
+        status: version(ver),
+        color: versionColor(ver)
+      }
+    case 'license':
+      return {
+        subject: 'license',
+        status: license || 'unknown',
+        color: 'blue'
+      }
+    case 'elm': {
+      const ver = formatElmVersion(elmVersion)
+      return {
+        subject: 'elm',
+        status: version(ver),
+        color: versionColor(ver)
+      }
+    }
+  }
+}
+
+function formatElmVersion (range: string) {
+  const parts = range.split(/\s+/g).filter(it => it !== 'v')
+  if (parts.length === 1) return parts[0]
+  let [lower, lowerOp, upperOp, upper] = parts
+  lowerOp = lowerOp.replace(/^</, '>')
+  return `${lowerOp}${lower} ${upperOp}${upper}`
+}

--- a/libs/badge-list.ts
+++ b/libs/badge-list.ts
@@ -32,6 +32,7 @@ export const liveBadgeList = [
   'opam',
   'cpan',
   'ctan',
+  'elm-package',
   'scoop',
   'winget',
   'f-droid',


### PR DESCRIPTION
This adds new handler powered by [Elm Package registry](https://package.elm-lang.org):

```
/elm-package/:topic<v|version|license|elm>/:owner/:name
```
where the topic can be one of:
- `v`/`version` (version)
- `license`
- `elm` (Elm version)

## Preview

![image](https://user-images.githubusercontent.com/1170440/104487259-2dcd0680-55cd-11eb-95f6-1f3e66076859.png)
