### PR TITLE
Implement CRAN service

### DIFF
--- a/api/cran.ts
+++ b/api/cran.ts
@@ -31,7 +31,7 @@ async function cranHandler ({ topic, pkg }: PathArgs) {
     case 'version': {
       const data = await client.get(pkg).json<any>()
       return {
-        subject: 'version',
+        subject: 'cran',
         status: version(data.Version),
         color: versionColor(data.Version)
       }

--- a/api/cran.ts
+++ b/api/cran.ts
@@ -1,0 +1,102 @@
+import got from '../libs/got'
+import { millify, version, versionColor } from '../libs/utils'
+import { createBadgenHandler, PathArgs } from '../libs/create-badgen-handler'
+
+const CRAN_API_URL = 'https://crandb.r-pkg.org/'
+const CRANLOGS_API_URL = 'https://cranlogs.r-pkg.org/'
+
+export default createBadgenHandler({
+  title: 'CRAN',
+  examples: {
+    '/cran/v/dplyr': 'version',
+    '/cran/license/ggplot2': 'license',
+    '/cran/r/data.table': 'r version',
+    '/cran/dt/Rcpp': 'total downloads',
+    '/cran/dd/Rcpp': 'daily downloads',
+    '/cran/dw/Rcpp': 'weekly downloads',
+    '/cran/dm/Rcpp': 'monthly downloads'
+  },
+  handlers: {
+    '/cran/:topic<v|version|license|r>/:pkg': cranHandler,
+    '/cran/:topic<dd|dw|dm|dt>/:pkg': cranlogsHandler
+  }
+})
+
+async function cranHandler ({ topic, pkg }: PathArgs) {
+  const client = got.extend({ prefixUrl: CRAN_API_URL })
+  const data = await client.get(pkg).json<any>()
+
+  switch (topic) {
+    case 'v':
+    case 'version':
+      return {
+        subject: 'version',
+        status: version(data.Version),
+        color: versionColor(data.Version)
+      }
+    case 'license': {
+      const license = data.License?.replace(/\s*\S\s+file\s+LICEN[CS]E$/i, '')
+      return {
+        subject: 'license',
+        status: license || 'unknown',
+        color: 'blue'
+      }
+    }
+    case 'r': {
+      const rVersion = data.Depends?.R?.replace(/([<>=]+)\s+/, '$1') || '*'
+      return {
+        subject: 'R',
+        status: version(rVersion),
+        color: versionColor(rVersion)
+      }
+    }
+  }
+}
+
+async function cranlogsHandler ({ topic, pkg }: PathArgs) {
+  switch (topic) {
+    case 'dt': {
+      const downloads = await fetchDownloads(pkg, 'total')
+      return {
+        subject: 'downloads',
+        status: millify(downloads),
+        color: 'green'
+      }
+    }
+    case 'dd': {
+      const downloads = await fetchDownloads(pkg, 'last-day')
+      return {
+        subject: 'downloads',
+        status: `${millify(downloads)}/day`,
+        color: 'green'
+      }
+    }
+    case 'dw': {
+      const downloads = await fetchDownloads(pkg, 'last-week')
+      return {
+        subject: 'downloads',
+        status: `${millify(downloads)}/week`,
+        color: 'green'
+      }
+    }
+    case 'dm': {
+      const downloads = await fetchDownloads(pkg, 'last-month')
+      return {
+        subject: 'downloads',
+        status: `${millify(downloads)}/month`,
+        color: 'green'
+      }
+    }
+  }
+}
+
+async function fetchDownloads (pkg: string, period: string) {
+  const client = got.extend({ prefixUrl: CRANLOGS_API_URL })
+  if (period === 'total') {
+    const [start] = new Date(0).toISOString().split('T')
+    const end = 'last-day'
+    period = [start, end].join(':')
+  }
+  const [stats] = await client.get(`downloads/total/${period}/${pkg}`).json()
+  return stats.downloads
+}

--- a/libs/badge-list.ts
+++ b/libs/badge-list.ts
@@ -31,6 +31,7 @@ export const liveBadgeList = [
   'haxelib',
   'opam',
   'cpan',
+  'cran',
   'ctan',
   'elm-package',
   'scoop',


### PR DESCRIPTION
This adds new handler/s powered by [METACRAN API](https://www.r-pkg.org/services#api) & [cranlogs.app](https://cranlogs.r-pkg.org/#jsonapi/):

```
/cran/:topic<v|version|license|r|dependents>/:pkg
/cran/:topic<dd|dw|dm|dt>/:pkg
```
where the topic can be one of:
- `v`/`version` (version)
- `license`
- `r` (R version)
- `dependents`
- `dd` (daily downloads)
- `dw` (weekly downloads)
- `dm` (monthly downloads)
- `dt` (total downloads)


## Preview

![image](https://user-images.githubusercontent.com/1170440/104954141-ffce3480-59c7-11eb-9bb9-79719c45989d.png)
