### PR TITLE
Add JCenter support to Maven service

### DIFF
--- a/api/maven.ts
+++ b/api/maven.ts
@@ -1,55 +1,48 @@
-import cheerio from 'cheerio'
 import got from '../libs/got'
 import { version as versionName, versionColor } from '../libs/utils'
 import { createBadgenHandler, PathArgs } from '../libs/create-badgen-handler'
+
+const MAVEN_CENTRAL_REPO_URL = 'https://repo1.maven.org/maven2/'
+const JCENTER_REPO_URL = 'https://jcenter.bintray.com/'
 
 export default createBadgenHandler({
   title: 'Maven',
   examples: {
     '/maven/v/maven-central/com.google.code.gson/gson': 'version (maven-central)',
+    '/maven/v/jcenter/com.squareup.okhttp3/okhttp': 'version (jcenter)',
     '/maven/v/metadata-url/https/repo1.maven.org/maven2/com/google/code/gson/gson/maven-metadata.xml': 'version (maven metadata url)',
   },
   handlers: {
-    '/maven/v/maven-central/:group/:artifact': mavenCentralHandler,
+    '/maven/v/:repo<maven-central|jcenter>/:group/:artifact': mavenRepoHandler,
     '/maven/v/metadata-url/:path+': mavenUrlHandler,
   }
 })
 
-async function mavenCentralHandler ({group, artifact}: PathArgs) {
+async function mavenRepoHandler ({ repo, group, artifact }: PathArgs) {
   group = group.replace(/\./g, '/')
-  const xml = await got(`https://repo1.maven.org/maven2/${group}/${artifact}/maven-metadata.xml`).text()
-  const version = getLastVersionFromMetadata(xml)
+  const endpoint = `${group}/${artifact}/maven-metadata.xml`
+
+  const repoUrl = {
+    'maven-central': MAVEN_CENTRAL_REPO_URL,
+    jcenter: JCENTER_REPO_URL
+  }[repo] || MAVEN_CENTRAL_REPO_URL
+
+  const xml = await got(endpoint, { prefixUrl: repoUrl }).text()
+  const version = xml.match(/<latest>([^<]+)<\//i)?.[1].trim() ?? 'unknown'
   return {
-    subject: 'maven-central',
+    subject: repo,
     status: versionName(version),
     color: versionColor(version)
   }
 }
 
-async function mavenUrlHandler ({path}: PathArgs) {
-  if (path.startsWith('http/')) {
-    path = path.slice(0, 4) + ':/' + path.slice(4)
-  } else if (path.startsWith('https/')) {
-    path = path.slice(0, 5) + ':/' + path.slice(5)
-  } else if (path.startsWith('http:/')) {
-    path = path.slice(0, 5) + '/' + path.slice(5)
-  } else if (path.startsWith('https:/')) {
-    path = path.slice(0, 6) + '/' + path.slice(6)
-  }
-  const xml = await got(path).text()
-  const version = getLastVersionFromMetadata(xml)
+async function mavenUrlHandler ({ path }: PathArgs) {
+  const url = path.replace(/^(https?):?\//, (_, scheme) => `${scheme}://`)
+  const xml = await got(url).text()
+  const version = xml.match(/<latest>([^<]+)<\//i)?.[1].trim() ?? 'unknown'
   return {
     subject: 'maven',
     status: versionName(version),
     color: versionColor(version)
   }
-}
-
-const getLastVersionFromMetadata = (xml: string) => {
-  const $ = cheerio.load(xml, {xmlMode: true})
-  const versions = $('metadata').children('versioning').children('versions').children('version')
-  if (versions.length === 0) {
-    return 'unknown'
-  }
-  return versions.last().text()
 }


### PR DESCRIPTION
This alters `/maven/v/maven-central/:group/:artifact` handler to:

```
/maven/v/:repo<maven-central|jcenter>/:group/:artifact
```

Additionally, it incorporates the following changes:
- refactoring Maven metadata param processing
- swapping `cheerio` with regexes

## Preview

![image](https://user-images.githubusercontent.com/1170440/106223154-2fa7e400-61e1-11eb-9675-fed61d092571.png)

---

Closes #480 