### PR TITLE
Add devRant score badge

### DIFF
--- a/api/devrant.ts
+++ b/api/devrant.ts
@@ -1,0 +1,38 @@
+import got from '../libs/got'
+import { millify } from '../libs/utils'
+import { createBadgenHandler, PathArgs } from '../libs/create-badgen-handler'
+
+const BRAND_COLOR = 'F99A66'
+const DEVRANT_API_URL = 'https://devrant.com/api'
+
+const client = got.extend({ prefixUrl: DEVRANT_API_URL })
+
+const upperCaseFirst = (input: string) => input.charAt(0).toUpperCase() + input.substr(1)
+
+export default createBadgenHandler({
+  title: 'devRant',
+  examples: {
+    '/devrant/score/22941?icon=devrant': 'score',
+    '/devrant/score/Tooma95?icon=devrant': 'score'
+  },
+  handlers: {
+    '/devrant/:topic<score>/:user-id<\\d+>': userIdHandler,
+    '/devrant/:topic<score>/:username': usernameHandler,
+  }
+})
+
+async function usernameHandler ({ username }: PathArgs) {
+  const searchParams = { username, app: 3 }
+  const { user_id } = await client.get('get-user-id', { searchParams }).json<any>()
+  return userIdHandler({ 'user-id': user_id })
+}
+
+async function userIdHandler ({ 'user-id': userId }: PathArgs) {
+  const searchParams = { app: 3 }
+  const { profile } = await client.get(`users/${userId}`, { searchParams }).json<any>()
+  return {
+    subject: upperCaseFirst(profile.username),
+    status: millify(profile.score),
+    color: BRAND_COLOR
+  }
+}

--- a/libs/badge-list.ts
+++ b/libs/badge-list.ts
@@ -58,6 +58,7 @@ export const liveBadgeList = [
   'badgesize',
   'jsdelivr',
   // social
+  'devrant',
   'peertube',
   // utilities
   'opencollective',


### PR DESCRIPTION
This adds new handler/s powered by [devRant](https://devrant.com) API:

```
/devrant/score/:user-id
/devrant/score/:username
```

## Preview

![image](https://user-images.githubusercontent.com/1170440/106228994-e3fb3780-61ec-11eb-9e7e-c85d29d454c3.png)

---

Inspired by #219 :grin: 