### PR TITLE
Fix Perl release & runtime version

### DIFF
--- a/api/cpan.ts
+++ b/api/cpan.ts
@@ -13,10 +13,11 @@ export default createBadgenHandler({
     '/cpan/license/Perl::Tidy': 'license',
     '/cpan/perl/Plack': 'perl version',
     '/cpan/size/Moose': 'size',
+    '/cpan/dependents/DateTime': 'dependents',
     '/cpan/likes/DBIx::Class': 'likes'
   },
   handlers: {
-    '/cpan/:topic<v|version|license|size|perl|likes>/:distribution': handler
+    '/cpan/:topic<v|version|license|size|perl|dependents|likes>/:distribution': handler
   }
 })
 
@@ -58,6 +59,15 @@ async function handler ({ topic, distribution }: PathArgs) {
         subject: 'perl',
         status: version(perlVersion),
         color: versionColor(perlVersion)
+      }
+    }
+    case 'dependents': {
+      const searchParams = { page_size: 1 }
+      const data = await client.get(`reverse_dependencies/dist/${distribution}`, { searchParams }).json<any>()
+      return {
+        subject: 'dependents',
+        status: millify(data.total),
+        color: 'green'
       }
     }
     case 'likes': {


### PR DESCRIPTION
Use API to get likes & runtime version - no more HTML scraping :tada: 
New _dependents_ badge :tada: 

## Before

![image](https://user-images.githubusercontent.com/1170440/106422983-d7324a00-645f-11eb-8c27-116114579385.png)

---

## After

![image](https://user-images.githubusercontent.com/1170440/106536491-ddc0d000-64f8-11eb-96be-2ff916620a7c.png)
