### PR TITLE
Millify Github & npm dependents count

### DIFF
--- a/api/npm.ts
+++ b/api/npm.ts
@@ -1,4 +1,3 @@
-import cheerio from 'cheerio'
 import got from '../libs/got'
 import { millify, version, versionColor } from '../libs/utils'
 import { createBadgenHandler, PathArgs, BadgenError } from '../libs/create-badgen-handler'
@@ -163,22 +162,22 @@ const download = async (period: string, npmName: string, tag = 'latest') => {
   }
 }
 
-// https://github.com/astur/check-npm-dependents/blob/master/index.js
 async function dependents (name: string) {
   const html = await got(`https://www.npmjs.com/package/${name}`,).text()
+  const count = Number(html.match(/"dependentsCount"\s*:\s*(\d+)/)?.[1])
 
+  if (Number.isNaN(count)) {
+    return {
+      subject: 'dependents',
+      status: 'invalid',
+      color: 'grey'
+    }
+  }
   return {
     subject: 'dependents',
-    status: parseDependents(html),
+    status: millify(count),
     color: 'green'
   }
-}
-
-const parseDependents = (html: string) => {
-  const $ = cheerio.load(html)
-  const depLink = $('a[href="?activeTab=dependents"]')
-  if (depLink.length !== 1) return -1
-  return depLink.text().replace(/[^0-9]/g, '')
 }
 
 async function typesDefinition(pkg: string, tag = 'latest') {


### PR DESCRIPTION
This is a continuation of #406 with `cheerio` being replaced by regexes :tada: 

## Before

![image](https://user-images.githubusercontent.com/1170440/83335259-dda66b80-a2ab-11ea-8348-3537f6f55a73.png)

---

## After

![image](https://user-images.githubusercontent.com/1170440/83335279-fc0c6700-a2ab-11ea-98c1-731e75eb3862.png)