### PR TITLE
Introduce Gitter and Matrix member count badges

### DIFF
--- a/api/gitter.ts
+++ b/api/gitter.ts
@@ -1,0 +1,39 @@
+import got from '../libs/got'
+import { millify } from '../libs/utils'
+import { createBadgenHandler, PathArgs } from '../libs/create-badgen-handler'
+
+const BRAND_COLOR = 'ED1965'
+
+export default createBadgenHandler({
+  title: 'Gitter',
+  examples: {
+    '/gitter/members/redom/lobby': 'members',
+    '/gitter/members/redom/redom': 'members'
+  },
+  handlers: {
+    '/gitter/members/:org/:room': handler
+  }
+})
+
+async function handler ({ org, room }: PathArgs) {
+  const membersCount = await fetchMembersCount(org, room)
+  if (Number.isNaN(membersCount)) {
+    return {
+      subject: 'gitter',
+      status: 'unknown',
+      color: 'grey'
+    }
+  }
+
+  const suffix = membersCount === 1 ? 'member' : 'members'
+  return {
+    subject: 'gitter',
+    status: `${millify(membersCount)} ${suffix}`,
+    color: BRAND_COLOR
+  }
+}
+
+export async function fetchMembersCount(org: string, room: string) {
+  const html = await got(`https://gitter.im/${org}/${room}`).text()
+  return Number(html.match(/"userCount"\s*:\s*([^,]+)/)?.[1])
+}

--- a/api/gitter.ts
+++ b/api/gitter.ts
@@ -35,5 +35,5 @@ async function handler ({ org, room }: PathArgs) {
 
 export async function fetchMembersCount(org: string, room: string) {
   const html = await got(`https://gitter.im/${org}/${room}`).text()
-  return Number(html.match(/"userCount"\s*:\s*([^,]+)/)?.[1])
+  return Number(html.match(/"userCount"\s*:\s*(\d+)/)?.[1])
 }

--- a/api/matrix.ts
+++ b/api/matrix.ts
@@ -8,8 +8,7 @@ const BRAND_COLOR = 'black'
 export default createBadgenHandler({
   title: 'Matrix',
   examples: {
-    '/matrix/members/%23rust/matrix.org': 'members',
-    '/matrix/members/Manjaro/matrix.org': 'members',
+    '/matrix/members/rust/matrix.org': 'members',
     '/matrix/members/thisweekinmatrix': 'members',
     '/matrix/members/archlinux/archlinux.org': 'members',
     '/matrix/members/redom_redom/gitter.im': 'members'

--- a/api/matrix.ts
+++ b/api/matrix.ts
@@ -1,0 +1,74 @@
+import got from '../libs/got'
+import { millify } from '../libs/utils'
+import { fetchMembersCount as fetchGitterMembersCount } from './gitter'
+import { createBadgenHandler, PathArgs } from '../libs/create-badgen-handler'
+
+const BRAND_COLOR = 'black'
+
+export default createBadgenHandler({
+  title: 'Matrix',
+  examples: {
+    '/matrix/members/%23rust/matrix.org': 'members',
+    '/matrix/members/Manjaro/matrix.org': 'members',
+    '/matrix/members/thisweekinmatrix': 'members',
+    '/matrix/members/archlinux/archlinux.org': 'members',
+    '/matrix/members/redom_redom/gitter.im': 'members'
+  },
+  handlers: {
+    '/matrix/members/:room/:server?': handler
+  }
+})
+
+async function handler ({ room, server = 'matrix.org' }: PathArgs) {
+  const roomName = room.replace(/^#/, '')
+  const membersCount = await fetchMembersCount(roomName, server)
+  if (Number.isNaN(membersCount)) {
+    return {
+      subject: 'matrix',
+      status: 'unknown',
+      color: 'grey'
+    }
+  }
+
+  const status = [
+    millify(membersCount),
+    server === 'gitter.im' ? 'gitter' : '',
+    membersCount === 1 ? 'member' : 'members'
+  ].join(' ')
+
+  return {
+    subject: `#${roomName}:${server}`,
+    status,
+    color: BRAND_COLOR
+  }
+}
+
+async function fetchMembersCount(roomName: string, server: string) {
+  if (server === 'gitter.im') {
+    const [gitterOrg, gitterRoom] = roomName.split('_')
+    return fetchGitterMembersCount(gitterOrg, gitterRoom)
+  }
+  const room = await findPublicRoom(roomName, server)
+  return room?.num_joined_members
+}
+
+async function findPublicRoom(roomName: string, server: string, homeserver?: string) {
+  homeserver = homeserver || await getHomeserver(server)
+  const roomAlias = `#${roomName}:${server}`
+  const endpoint = `${homeserver}/_matrix/client/api/v1/publicRooms`
+  const searchParams = new URLSearchParams({ limit: '500' })
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    const { chunk, next_batch } = await got(endpoint, { searchParams }).json<any>()
+    const room = chunk.find(it => it.canonical_alias === roomAlias)
+    if (room) return room
+    if (!next_batch) return
+    searchParams.set('since', next_batch)
+  }
+}
+
+async function getHomeserver(server: string) {
+  const endpoint = `https://${server}/.well-known/matrix/client`
+  const { 'm.homeserver': homeserver } = await got(endpoint).json()
+  return homeserver?.base_url
+}

--- a/api/matrix.ts
+++ b/api/matrix.ts
@@ -1,3 +1,4 @@
+import { Got } from 'got'
 import got from '../libs/got'
 import { millify } from '../libs/utils'
 import { fetchMembersCount as fetchGitterMembersCount } from './gitter'
@@ -47,27 +48,37 @@ async function fetchMembersCount(roomName: string, server: string) {
     const [gitterOrg, gitterRoom] = roomName.split('_')
     return fetchGitterMembersCount(gitterOrg, gitterRoom)
   }
-  const room = await findPublicRoom(roomName, server)
+  const homeserver = await getHomeserver(server)
+  const client = got.extend({ prefixUrl: `${homeserver}/_matrix/client/r0` })
+  const roomAlias = `#${roomName}:${server}`
+  const room = await findPublicRoom(client, roomAlias)
   return room?.num_joined_members
 }
 
-async function findPublicRoom(roomName: string, server: string, homeserver?: string) {
-  homeserver = homeserver || await getHomeserver(server)
-  const roomAlias = `#${roomName}:${server}`
-  const endpoint = `${homeserver}/_matrix/client/api/v1/publicRooms`
+// https://matrix.org/docs/spec/client_server/latest#get-well-known-matrix-client
+async function getHomeserver(server: string) {
+  const endpoint = `https://${server}/.well-known/matrix/client`
+  const { 'm.homeserver': homeserver } = await got(endpoint).json<any>()
+  return homeserver?.base_url
+}
+
+// https://matrix.org/docs/spec/client_server/latest#get-matrix-client-r0-publicrooms
+async function findPublicRoom(client: Got, roomAlias: string) {
+  const roomId = await getRoomId(client, roomAlias)
   const searchParams = new URLSearchParams({ limit: '500' })
   // eslint-disable-next-line no-constant-condition
   while (true) {
-    const { chunk, next_batch } = await got(endpoint, { searchParams }).json<any>()
-    const room = chunk.find(it => it.canonical_alias === roomAlias)
+    const { chunk, next_batch } = await client.get('publicRooms', { searchParams }).json<any>()
+    const room = chunk.find(it => it.room_id === roomId)
     if (room) return room
     if (!next_batch) return
     searchParams.set('since', next_batch)
   }
 }
 
-async function getHomeserver(server: string) {
-  const endpoint = `https://${server}/.well-known/matrix/client`
-  const { 'm.homeserver': homeserver } = await got(endpoint).json()
-  return homeserver?.base_url
+// https://matrix.org/docs/spec/client_server/latest#get-matrix-client-r0-directory-room-roomalias
+async function getRoomId(client: Got, roomAlias: string) {
+  const endpoint = `directory/room/${encodeURIComponent(roomAlias)}`
+  const { room_id } = await client.get(endpoint).json<any>()
+  return room_id
 }

--- a/libs/badge-list.ts
+++ b/libs/badge-list.ts
@@ -63,6 +63,7 @@ export const liveBadgeList = [
   'peertube',
   // chat
   'gitter',
+  'matrix',
   // utilities
   'opencollective',
   'keybase',

--- a/libs/badge-list.ts
+++ b/libs/badge-list.ts
@@ -61,6 +61,8 @@ export const liveBadgeList = [
   // social
   'devrant',
   'peertube',
+  // chat
+  'gitter',
   // utilities
   'opencollective',
   'keybase',


### PR DESCRIPTION
This PR adds support for Gitter and Matrix badges. Former is powered by scraping public Gitter rooms while latter uses Matrix client API to obtain public room information. :tada: 

## Preview

![image](https://user-images.githubusercontent.com/1170440/107243455-4e05af00-6a2d-11eb-8ddb-9c288a595a51.png)

In response to https://github.com/badgen/badgen.net/issues/362#issuecomment-601659346
> Looks like two more live badges to go, discourse and matrix.

One down, one more to go :wink: 
