### PR TITLE
Add support for Open VSX ratings

### DIFF
--- a/api/open-vsx.ts
+++ b/api/open-vsx.ts
@@ -6,11 +6,11 @@ import { createBadgenHandler, PathArgs } from '../libs/create-badgen-handler'
 export default createBadgenHandler({
   title: 'Open VSX',
   examples: {
-    '/open-vsx/version/idleberg/electron-builder': 'version',
+    '/open-vsx/downloads/idleberg/electron-builder': 'downloads',
+    '/open-vsx/license/idleberg/electron-builder': 'license',
     '/open-vsx/rating/idleberg/electron-builder': 'rating',
     '/open-vsx/reviews/idleberg/electron-builder': 'reviews',
-    '/open-vsx/license/idleberg/electron-builder': 'license',
-    '/open-vsx/downloads/idleberg/electron-builder': 'downloads'
+    '/open-vsx/version/idleberg/electron-builder': 'version'
   },
   handlers: {
     '/open-vsx/:topic<downloads|license|rating|reviews|version>/:namespace/:pkg': handler

--- a/api/open-vsx.ts
+++ b/api/open-vsx.ts
@@ -55,7 +55,7 @@ async function handler ({ topic, pkg, namespace }: PathArgs) {
     default:
       return {
         subject: 'Open VSX',
-        status: 'unknown topic',
+        status: 'unknown',
         color: 'grey'
       }
   }

--- a/api/open-vsx.ts
+++ b/api/open-vsx.ts
@@ -13,7 +13,7 @@ export default createBadgenHandler({
     '/open-vsx/version/idleberg/electron-builder': 'version'
   },
   handlers: {
-    '/open-vsx/:topic<downloads|license|rating|reviews|version>/:namespace/:pkg': handler
+    '/open-vsx/:topic<d|l|license|rating|reviews|v|version>/:namespace/:pkg': handler
   }
 })
 

--- a/api/open-vsx.ts
+++ b/api/open-vsx.ts
@@ -6,7 +6,6 @@ import { createBadgenHandler, PathArgs } from '../libs/create-badgen-handler'
 export default createBadgenHandler({
   title: 'Open VSX',
   examples: {
-    '/open-vsx/downloads/idleberg/electron-builder': 'downloads',
     '/open-vsx/d/idleberg/electron-builder': 'downloads',
     '/open-vsx/license/idleberg/electron-builder': 'license',
     '/open-vsx/rating/idleberg/electron-builder': 'rating',
@@ -31,7 +30,6 @@ async function handler ({ topic, pkg, namespace }: PathArgs) {
         color: versionColor(data.version)
       }
     case 'd':
-    case 'downloads':
       return {
         subject: 'downloads',
         status: millify(data.downloadCount),

--- a/api/open-vsx.ts
+++ b/api/open-vsx.ts
@@ -56,11 +56,5 @@ async function handler ({ topic, pkg, namespace }: PathArgs) {
         status: millify(data.reviewCount),
         color: 'green'
       }
-    default:
-      return {
-        subject: 'Open VSX',
-        status: 'unknown',
-        color: 'grey'
-      }
   }
 }

--- a/api/open-vsx.ts
+++ b/api/open-vsx.ts
@@ -7,6 +7,7 @@ export default createBadgenHandler({
   title: 'Open VSX',
   examples: {
     '/open-vsx/downloads/idleberg/electron-builder': 'downloads',
+    '/open-vsx/d/idleberg/electron-builder': 'downloads',
     '/open-vsx/license/idleberg/electron-builder': 'license',
     '/open-vsx/rating/idleberg/electron-builder': 'rating',
     '/open-vsx/reviews/idleberg/electron-builder': 'reviews',

--- a/api/open-vsx.ts
+++ b/api/open-vsx.ts
@@ -22,18 +22,21 @@ async function handler ({ topic, pkg, namespace }: PathArgs) {
   const data = await got(endpoint).json<any>()
 
   switch (topic) {
+    case 'v':
     case 'version':
       return {
         subject: `version`,
         status: version(data.version),
         color: versionColor(data.version)
       }
+    case 'd':
     case 'downloads':
       return {
         subject: 'downloads',
         status: millify(data.downloadCount),
         color: 'green'
       }
+    case 'l':
     case 'license':
       return {
         subject: 'license',

--- a/api/open-vsx.ts
+++ b/api/open-vsx.ts
@@ -42,6 +42,12 @@ async function handler ({ topic, pkg, namespace }: PathArgs) {
         status: data.license || 'unknown',
         color: 'blue'
       }
+    case 'rating':
+      return {
+        subject: 'rating',
+        status: `${data.averageRating}/5`,
+        color: 'green'
+      }
     case 'r':
     case 'reviews':
       return {

--- a/api/open-vsx.ts
+++ b/api/open-vsx.ts
@@ -6,13 +6,14 @@ import { createBadgenHandler, PathArgs } from '../libs/create-badgen-handler'
 export default createBadgenHandler({
   title: 'Open VSX',
   examples: {
-    '/open-vsx/v/idleberg/electron-builder': 'version',
-    '/open-vsx/r/idleberg/electron-builder': 'reviews',
-    '/open-vsx/l/idleberg/electron-builder': 'license',
-    '/open-vsx/d/idleberg/electron-builder': 'downloads'
+    '/open-vsx/version/idleberg/electron-builder': 'version',
+    '/open-vsx/rating/idleberg/electron-builder': 'rating',
+    '/open-vsx/reviews/idleberg/electron-builder': 'reviews',
+    '/open-vsx/license/idleberg/electron-builder': 'license',
+    '/open-vsx/downloads/idleberg/electron-builder': 'downloads'
   },
   handlers: {
-    '/open-vsx/:topic/:namespace/:pkg': handler
+    '/open-vsx/:topic<downloads|license|rating|reviews|version>/:namespace/:pkg': handler
   }
 })
 
@@ -21,21 +22,18 @@ async function handler ({ topic, pkg, namespace }: PathArgs) {
   const data = await got(endpoint).json<any>()
 
   switch (topic) {
-    case 'v':
     case 'version':
       return {
         subject: `version`,
         status: version(data.version),
         color: versionColor(data.version)
       }
-    case 'd':
     case 'downloads':
       return {
         subject: 'downloads',
         status: millify(data.downloadCount),
         color: 'green'
       }
-    case 'l':
     case 'license':
       return {
         subject: 'license',
@@ -48,7 +46,6 @@ async function handler ({ topic, pkg, namespace }: PathArgs) {
         status: `${data.averageRating}/5`,
         color: 'green'
       }
-    case 'r':
     case 'reviews':
       return {
         subject: 'reviews',


### PR DESCRIPTION
I somehow missed the ratings option in the Open VSX API. But now that there are two topics with the letter `r`, I'm having second thoughts about the abbreviated forms. Any opinions on whether I should remove that or do you fear a breaking change like this?

I'm wondering why there's no recommendation or at least a standardized way for some of these (e.g. I've seen `d` and `dl` as short forms for `downloads`). Personally, when in doubt, I'd opt for the full name topics.