### PR TITLE
Add endpoint for PyPi Python versions

### DIFF
--- a/api/pypi.ts
+++ b/api/pypi.ts
@@ -1,4 +1,5 @@
 import got from '../libs/got'
+import { compare, coerce } from 'semver'
 import { version, versionColor } from '../libs/utils'
 import { createBadgenHandler, PathArgs } from '../libs/create-badgen-handler'
 
@@ -8,11 +9,29 @@ export default createBadgenHandler({
     '/pypi/v/pip': 'version',
     '/pypi/v/docutils': 'version',
     '/pypi/license/pip': 'license',
+    '/pypi/pyversions/black': 'python version',
   },
   handlers: {
-    '/pypi/:topic<v|license>/:project': handler
+    '/pypi/:topic<v|license|pyversions>/:project': handler
   }
 })
+
+// Extract classifiers from a pypi json response based on a regex.
+// Source: https://github.com/badges/shields/blob/cf7c9c11471bb227069c013657491d842f6c7940/services/pypi/pypi-helpers.js#L42
+function parseClassifiers(parsedInfo: any, pattern: RegExp, preserveCase = false): string[] {
+  const results: string[] = []
+  for (let i = 0; i < parsedInfo.classifiers.length; i++) {
+    const matched = pattern.exec(parsedInfo.classifiers[i])
+    if (matched && matched[1]) {
+      if (preserveCase) {
+        results.push(matched[1])
+      } else {
+        results.push(matched[1].toLowerCase())
+      }
+    }
+  }
+  return results
+}
 
 async function handler ({ topic, project }: PathArgs) {
   const endpoint = `https://pypi.org/pypi/${project}/json`
@@ -30,6 +49,57 @@ async function handler ({ topic, project }: PathArgs) {
         subject: 'license',
         status: info.license || 'unknown',
         color: 'blue'
+      }
+    case 'pyversions':
+      // Source: https://github.com/badges/shields/blob/cf7c9c11471bb227069c013657491d842f6c7940/services/pypi/pypi-python-versions.service.js
+
+      const versions = parseClassifiers(
+        info,
+        /^Programming Language :: Python :: ([\d.]+)$/
+      )
+
+      // If no versions are found yet, check "X :: Only" as a fallback.
+      if (versions.length === 0) {
+        versions.push(
+          ...parseClassifiers(
+            info,
+            /^Programming Language :: Python :: (\d+) :: Only$/
+          )
+        )
+      }
+
+      const versionSet: Set<string> = new Set(versions);
+
+      // We only show v2 if eg. v2.4 does not appear.
+      // See https://github.com/badges/shields/pull/489 for more.
+      ['2', '3'].forEach(majorVersion => {
+        if (Array.from(versions).some(v => v.startsWith(`${majorVersion}.`))) {
+          versionSet.delete(majorVersion)
+        }
+      })
+
+      if (versionSet.size == 0) {
+        return {
+          subject: 'python',
+          status: 'missing',
+          color: 'red'
+        }
+      }
+
+      return {
+        subject: 'python',
+        status: Array.from(versionSet)
+          .sort((v1, v2) => {
+            try {
+              return compare(coerce(v1) ?? v1, coerce(v2) ?? v2)
+            } catch (e) {
+              if (v1 < v2) return -1
+              if (v1 > v2) return 1
+              return 0
+            }
+          })
+          .join(' | '),
+        color: versions.length ? 'blue' : 'red'
       }
   }
 }


### PR DESCRIPTION
This badge displays Python versions from the Classifiers of a PyPi package.

<img width="504" alt="grafik" src="https://user-images.githubusercontent.com/6566248/109855544-b32d7880-7c58-11eb-9a76-a501dc832dc1.png">

The code is almost completely [taken from Shields.io](https://github.com/badges/shields/blob/cf7c9c11471bb227069c013657491d842f6c7940/services/pypi/pypi-python-versions.service.js) — I don't know whether that's okay or not.

Anyway, I've tested it, and it seems to work :+1: