### PR TITLE
Add Python version support to PyPI service

### DIFF
--- a/api/pypi.ts
+++ b/api/pypi.ts
@@ -1,4 +1,5 @@
 import got from '../libs/got'
+import { coerce, compare, SemVer } from 'semver'
 import { version, versionColor } from '../libs/utils'
 import { createBadgenHandler, PathArgs } from '../libs/create-badgen-handler'
 
@@ -8,9 +9,10 @@ export default createBadgenHandler({
     '/pypi/v/pip': 'version',
     '/pypi/v/docutils': 'version',
     '/pypi/license/pip': 'license',
+    '/pypi/python/black': 'python version',
   },
   handlers: {
-    '/pypi/:topic<v|license>/:project': handler
+    '/pypi/:topic<v|license|python>/:project': handler
   }
 })
 
@@ -31,5 +33,43 @@ async function handler ({ topic, project }: PathArgs) {
         status: info.license || 'unknown',
         color: 'blue'
       }
+    case 'python': {
+      const { standard, exclusive } = readVersions(info.classifiers)
+      const versions = (standard.length ? standard : exclusive).join(' | ')
+      return {
+        subject: 'python',
+        status: versions || 'unknown',
+        color: versions ? 'blue' : 'grey'
+      }
+    }
   }
+}
+
+function readVersions(classifiers: string[]) {
+  const reVersionClassifier = /^Programming Language :: Python :: ([\d.]+)( :: Only)?$/i
+  const versions = classifiers.reduce((acc, classifier) => {
+    const match = classifier.match(reVersionClassifier)
+    if (!match) return acc
+    const [, source, isExclusive] = match
+    const version = coerce(source)
+    if (!version) return acc
+    const versionDict = isExclusive ? acc.exclusive : acc.standard
+    versionDict.delete(version.major.toString())
+    versionDict.set(source, version)
+    return acc
+  }, {
+    standard: new Map<string, SemVer>(),
+    exclusive: new Map<string, SemVer>()
+  })
+  const compareFn = (source1: string, source2: string, versionDict: Map<string, SemVer>) => {
+    return compare(versionDict.get(source1)!, versionDict.get(source2)!)
+  }
+  return {
+    standard: sortKeys(versions.standard, compareFn),
+    exclusive: sortKeys(versions.exclusive, compareFn)
+  }
+}
+
+function sortKeys<K, V>(map: Map<K, V>, compareFn: (a: K, b: K, map: Map<K, V>) => number) {
+  return Array.from(map.keys()).sort((a, b) => compareFn(a, b, map))
 }


### PR DESCRIPTION
This extends the existing PyPI service with a new handler for generating badge listing supported Python versions:
```
/pypi/python/:project
```

## Preview

![image](https://user-images.githubusercontent.com/1170440/113462995-e6b01e00-9423-11eb-94c8-c3bdce18830c.png)

---

This is based on @NickKaramoff's work made in #513 Due to lack of activity there, I decided to take my patch and convert it into another PR which closes #513.