### PR TITLE
docs: remove repeated word in https documentation

### DIFF
--- a/api/https.ts
+++ b/api/https.ts
@@ -21,7 +21,7 @@ or any platform, which returns a JSON in this format:
    https://some-endpoint.example.com/what/ever/args
    \`\`\`
 
-   then then the corresponding badge url on Badgen is:
+   then the corresponding badge url on Badgen is:
 
    \`\`\`
    /https/some-endpoint.example.com/what/ever/args


### PR DESCRIPTION
Removes unnecessary `then` from the second step of the "Use Badgen with HTTPS Endpoint" example