### PR TITLE
fix(npm): license field removed from meta api (fix #436)

### DIFF
--- a/api/npm.ts
+++ b/api/npm.ts
@@ -92,10 +92,10 @@ async function pkgJson (pkg: string, tag = 'latest'): Promise<any> {
 }
 
 async function info (topic: string, pkg: string, tag = 'latest') {
-  // ver === 'latest', non-scoped package use npmMetadata (npm), all others use unpkg
+  // private package use npmMetadata (npm), all others use unpkg
   // optionally disable unpkg to request all info from NPM
   const meta = await(
-    process.env.NPM_REGISTRY || (tag === "latest" && pkg.startsWith('@'))
+    process.env.NPM_REGISTRY
       ? npmMetadata(pkg, tag)
       : pkgJson(pkg, tag)
   )


### PR DESCRIPTION
Seems npm removed `license` field from their package meta api.