### PR TITLE
Add total downloads support to NuGet

### DIFF
--- a/api/nuget.ts
+++ b/api/nuget.ts
@@ -1,16 +1,18 @@
 import got from '../libs/got'
-import { version, versionColor } from '../libs/utils'
+import { millify, version, versionColor } from '../libs/utils'
 import { createBadgenHandler, PathArgs } from '../libs/create-badgen-handler'
 
 export default createBadgenHandler({
-  title: 'Nuget',
+  title: 'NuGet',
   examples: {
-    '/nuget/v/newtonsoft.json': 'version (stable channel)',
-    '/nuget/v/newtonsoft.json/pre': 'version (pre channel)',
-    '/nuget/v/newtonsoft.json/latest': 'version (latest channel)',
+    '/nuget/v/Newtonsoft.Json': 'version (stable channel)',
+    '/nuget/v/Newtonsoft.Json/pre': 'version (pre channel)',
+    '/nuget/v/Newtonsoft.Json/latest': 'version (latest channel)',
+    '/nuget/dt/Newtonsoft.Json': 'total downloads',
   },
   handlers: {
-    '/nuget/v/:project/:channel?': handler
+    '/nuget/v/:project/:channel?': handler,
+    '/nuget/dt/:project': downloads
   }
 })
 
@@ -19,7 +21,7 @@ const stable = versions => versions.filter(v => !v.includes('-'))
 const latest = versions => versions.length > 0 && versions.slice(-1)[0]
 
 async function handler ({ project, channel }: PathArgs) {
-  const endpoint = `https://api.nuget.org/v3-flatcontainer/${project}/index.json`
+  const endpoint = `https://api.nuget.org/v3-flatcontainer/${project.toLowerCase()}/index.json`
   const { versions } = await got(endpoint).json<any>()
 
   let ver = ''
@@ -43,5 +45,21 @@ async function handler ({ project, channel }: PathArgs) {
     subject: 'nuget',
     status: version(ver),
     color: versionColor(ver)
+  }
+}
+
+async function downloads ({ project }: PathArgs) {
+  const endpoint = `https://azuresearch-usnc.nuget.org/query`
+  const searchParams = {
+    q: `packageid:${project.toLowerCase()}`,
+    prerelease: true,
+    semVerLevel: 2
+  }
+  const { data } = await got.get(endpoint, { searchParams }).json<any>()
+
+  return {
+    subject: 'downloads',
+    status: millify(data[0].totalDownloads),
+    color: 'green'
   }
 }


### PR DESCRIPTION
Add support for total downloads to the existing NuGet badge. NuGet package IDs are treated as all lowercase in the API, so I've added lowercase conversion to the existing badge.

```
/nuget/dt/:project
```

### Preview

![image](https://user-images.githubusercontent.com/1356444/128598282-920d6f3d-1d99-4078-a869-7d1047b06142.png)
