### PR TITLE
fix(github): Cover all conclusion enums in the GitHub check-runs API

### DIFF
--- a/api/github.ts
+++ b/api/github.ts
@@ -89,14 +89,16 @@ const statesColor = {
   unknown: 'grey'
 }
 
+// https://docs.github.com/en/rest/checks/runs#list-check-runs-for-a-git-reference
 function combined (states: Array<any>, stateKey: string = 'state') {
   if (states.length === 0) return 'unknown'
 
-  if (states.find(x => x[stateKey] === 'error')) return 'error'
   if (states.find(x => x[stateKey] === 'failure')) return 'failure'
-  if (states.find(x => x[stateKey] === 'pending')) return 'pending'
+  if (states.find(x => x[stateKey] === 'timed_out')) return 'timed_out'
+  if (states.find(x => x[stateKey] === 'action_required')) return 'action_required'
 
   const succeeded = states
+    .filter(x => x[stateKey] !== 'neutral')
     .filter(x => x[stateKey] !== 'cancelled')
     .filter(x => x[stateKey] !== 'skipped')
     .every(x => x[stateKey] === 'success')


### PR DESCRIPTION
Hi! Thank you for a cool service 😆

I found that when I try to make some of my badges for GitHub checks, I get 500 errors.
e.g. <https://badgen.net/github/checks/blooper05/action-rails_best_practices>

I have investigated and found that the checks in those errored repositories contain the `neutral` on `conclusion` property.
I also read the documents accordingly and found that there are other `conclusion`s that are not covered by the current implementation.
ref. <https://docs.github.com/en/rest/checks/runs#list-check-runs-for-a-git-reference>

So, I have fixed these issues 👍 
Please check my changes and merge them if you like them. Thanks!
