### PR TITLE
fix(api/npm): scan `exports` for types

### DIFF
--- a/api/npm.ts
+++ b/api/npm.ts
@@ -183,15 +183,17 @@ async function dependents (name: string) {
 async function typesDefinition(pkg: string, tag = 'latest') {
   let meta = await pkgJson(pkg, tag)
 
-  const hasExportTypes = (meta: any) => {
+  const hasTypes = (meta: any) => {
     if (typeof meta.types === 'string' || typeof meta.typings === 'string') {
       return true
     }
-    const hasNestedTypes = (exports: any) =>
-      typeof exports === 'object' &&
-      (typeof exports.types === 'string' ||
-      Object.values(exports)
-        .some(hasNestedTypes))
+
+    const hasNestedTypes = (exports: any) => {
+  		if (typeof exports !== 'object') return false
+  		if (typeof exports.types === 'string') return true
+  		if (Object.values(exports).some(hasNestedTypes)) return true
+  		return false
+		}
 
     if (hasNestedTypes(meta.exports)) {
       return true
@@ -200,7 +202,7 @@ async function typesDefinition(pkg: string, tag = 'latest') {
     return false
   }
 
-  if (hasExportTypes(meta)) {
+  if (hasTypes(meta)) {
     return {
       subject: 'types',
       status: 'included',

--- a/api/npm.ts
+++ b/api/npm.ts
@@ -183,17 +183,35 @@ async function dependents (name: string) {
 async function typesDefinition(pkg: string, tag = 'latest') {
   let meta = await pkgJson(pkg, tag)
 
-  if (typeof meta.types === 'string' || typeof meta.typings === "string") {
+  const hasExportTypes = (meta: any) => {
+    if (typeof meta.types === 'string' || typeof meta.typings === 'string') {
+      return true
+    }
+    const hasNestedTypes = (exports: any) =>
+      typeof exports.types === 'string' ||
+      Object.values(exports ?? {})
+        .filter((nestedExport: any) => typeof nestedExport === 'object')
+        .some(hasNestedTypes)
+
+    if (hasNestedTypes(meta.exports)) {
+      return true
+    }
+
+    return false
+  }
+
+  if (hasExportTypes(meta)) {
     return {
       subject: 'types',
       status: 'included',
-      color: '0074c1'
+      color: '0074c1',
     }
   }
 
-  const hasIndexDTSFile = await got.head(`https://unpkg.com/${pkg}/index.d.ts`)
-    .then(res => res.statusCode === 200)
-    .catch(e => false)
+  const hasIndexDTSFile = await got
+    .head(`https://unpkg.com/${pkg}/index.d.ts`)
+    .then((res) => res.statusCode === 200)
+    .catch((e) => false)
 
   if (hasIndexDTSFile) {
     return {

--- a/api/npm.ts
+++ b/api/npm.ts
@@ -189,9 +189,9 @@ async function typesDefinition(pkg: string, tag = 'latest') {
     }
 
     const hasNestedTypes = (exports: any) => {
-  		if (typeof exports !== 'object') return false
-  		if (typeof exports.types === 'string') return true
-  		if (Object.values(exports).some(hasNestedTypes)) return true
+      if (typeof exports !== 'object') return false
+      if (typeof exports.types === 'string') return true
+      if (Object.values(exports).some(hasNestedTypes)) return true
       return false
     }
 

--- a/api/npm.ts
+++ b/api/npm.ts
@@ -188,10 +188,10 @@ async function typesDefinition(pkg: string, tag = 'latest') {
       return true
     }
     const hasNestedTypes = (exports: any) =>
-      typeof exports.types === 'string' ||
-      Object.values(exports ?? {})
-        .filter((nestedExport: any) => typeof nestedExport === 'object')
-        .some(hasNestedTypes)
+      typeof exports === 'object' &&
+      (typeof exports.types === 'string' ||
+      Object.values(exports)
+        .some(hasNestedTypes))
 
     if (hasNestedTypes(meta.exports)) {
       return true

--- a/api/npm.ts
+++ b/api/npm.ts
@@ -192,8 +192,8 @@ async function typesDefinition(pkg: string, tag = 'latest') {
   		if (typeof exports !== 'object') return false
   		if (typeof exports.types === 'string') return true
   		if (Object.values(exports).some(hasNestedTypes)) return true
-  		return false
-		}
+      return false
+    }
 
     if (hasNestedTypes(meta.exports)) {
       return true


### PR DESCRIPTION
Types can also be specified in the `exports` property of `package.json` files.
Since this property supports [multiple levels of nesting](https://nodejs.org/api/packages.html#nested-conditions), my proposal recursively scans them all.