### PR TITLE
fix(api/gitlab): remove leading slashes in restPaths

### DIFF
--- a/api/gitlab.ts
+++ b/api/gitlab.ts
@@ -231,18 +231,18 @@ const makeQueryCall = async ({ topic, owner, repo, ...restArgs }) => {
 
 const makeRestCall = async ({ topic, owner, repo, ...restArgs }) => {
   const restPaths = {
-    'mrs': `/projects/${encodeURIComponent(`${owner}/${repo}`)}/merge_requests`,
-    'open-mrs': `/projects/${encodeURIComponent(`${owner}/${repo}`)}/merge_requests?state=opened`,
-    'closed-mrs': `/projects/${encodeURIComponent(`${owner}/${repo}`)}/merge_requests?state=closed`,
-    'merged-mrs': `/projects/${encodeURIComponent(`${owner}/${repo}`)}/merge_requests?state=merged`,
-    'commits': `/projects/${encodeURIComponent(`${owner}/${repo}`)}/repository/commits?${restArgs.ref ? "ref_name=" + restArgs.ref : ''}`,
-    'last-commit': `/projects/${encodeURIComponent(`${owner}/${repo}`)}/repository/commits?${restArgs.ref ? "ref_name=" + restArgs.ref : ''}`,
-    'branches': `/projects/${encodeURIComponent(`${owner}/${repo}`)}/repository/branches`,
-    'tags': `/projects/${encodeURIComponent(`${owner}/${repo}`)}/repository/tags`,
-    'contributors': `/projects/${encodeURIComponent(`${owner}/${repo}`)}/repository/contributors`,
-    'releases': `/projects/${encodeURIComponent(`${owner}/${repo}`)}/releases`,
-    'release': `/projects/${encodeURIComponent(`${owner}/${repo}`)}/releases`,
-    'license': `/projects/${encodeURIComponent(`${owner}/${repo}`)}?license=true`,
+    'mrs': `projects/${encodeURIComponent(`${owner}/${repo}`)}/merge_requests`,
+    'open-mrs': `projects/${encodeURIComponent(`${owner}/${repo}`)}/merge_requests?state=opened`,
+    'closed-mrs': `projects/${encodeURIComponent(`${owner}/${repo}`)}/merge_requests?state=closed`,
+    'merged-mrs': `projects/${encodeURIComponent(`${owner}/${repo}`)}/merge_requests?state=merged`,
+    'commits': `projects/${encodeURIComponent(`${owner}/${repo}`)}/repository/commits?${restArgs.ref ? "ref_name=" + restArgs.ref : ''}`,
+    'last-commit': `projects/${encodeURIComponent(`${owner}/${repo}`)}/repository/commits?${restArgs.ref ? "ref_name=" + restArgs.ref : ''}`,
+    'branches': `projects/${encodeURIComponent(`${owner}/${repo}`)}/repository/branches`,
+    'tags': `projects/${encodeURIComponent(`${owner}/${repo}`)}/repository/tags`,
+    'contributors': `projects/${encodeURIComponent(`${owner}/${repo}`)}/repository/contributors`,
+    'releases': `projects/${encodeURIComponent(`${owner}/${repo}`)}/releases`,
+    'release': `projects/${encodeURIComponent(`${owner}/${repo}`)}/releases`,
+    'license': `projects/${encodeURIComponent(`${owner}/${repo}`)}?license=true`,
   }
 
   let restPath = restPaths[topic]


### PR DESCRIPTION
Leading slashes in `input` are disallowed  when using `prefixUrl` option. [Reference1](https://github.com/sindresorhus/got/blob/4d12bbd7e18866739254ac0f256b850a3d58dba6/source/core/options.ts#L1230) [Reference2](https://github.com/sindresorhus/got/blob/4cdcca382659050e1c73c7eb9542c8fb871d10aa/test/arguments.ts#L434-L439)
Fix #564

I have test it: [/gitlab/last-commit/gitlab-org/gitlab-development-kit](https://badgen-gitlab.vercel.app/gitlab/last-commit/gitlab-org/gitlab-development-kit) ![](https://badgen-gitlab.vercel.app/gitlab/last-commit/gitlab-org/gitlab-development-kit).
The badgens for `commits count` or `branches` are broken because gitlab api changed.