### PR TITLE
Use default branch for GitHub commits when appropriate

### DIFF
--- a/api/github.ts
+++ b/api/github.ts
@@ -309,8 +309,8 @@ const makeRepoQuery = (topic, owner, repo, restArgs) => {
       queryBody = `
         ${
           restArgs.ref
-            ? `branch: ref(qualifiedName: "${restArgs.ref || "master"}")`
-            : `defaultBranchRef`
+            ? `branch: ref(qualifiedName: "${restArgs.ref}")`
+            : 'defaultBranchRef'
         } {          
           target {
             ... on Commit {
@@ -326,8 +326,8 @@ const makeRepoQuery = (topic, owner, repo, restArgs) => {
       queryBody = `
         ${
           restArgs.ref ? 
-            `branch: ref(qualifiedName: "${restArgs.ref || 'master'}")` :
-            `defaultBranchRef`
+            `branch: ref(qualifiedName: "${restArgs.ref}")` :
+            'defaultBranchRef'
         } {
           target {
             ... on Commit {

--- a/api/github.ts
+++ b/api/github.ts
@@ -307,7 +307,11 @@ const makeRepoQuery = (topic, owner, repo, restArgs) => {
       break
     case 'commits':
       queryBody = `
-        branch: ref(qualifiedName: "${restArgs.ref || 'master'}") {
+        ${
+          restArgs.ref
+            ? `branch: ref(qualifiedName: "${restArgs.ref || "master"}")`
+            : `defaultBranchRef`
+        } {          
           target {
             ... on Commit {
               history(first: 0) {
@@ -320,7 +324,11 @@ const makeRepoQuery = (topic, owner, repo, restArgs) => {
       break
     case 'last-commit':
       queryBody = `
-        branch: ref(qualifiedName: "${restArgs.ref || 'master'}") {
+        ${
+          restArgs.ref ? 
+            `branch: ref(qualifiedName: "${restArgs.ref || 'master'}")` :
+            `defaultBranchRef`
+        } {
           target {
             ... on Commit {
               history(first: 1) {
@@ -429,7 +437,11 @@ async function repoStats ({topic, owner, repo, ...restArgs}: PathArgs) {
     case 'commits':
       return {
         subject: topic,
-        status: millify(result.branch.target.history.totalCount),
+        status: millify(
+          result.branch ? 
+            result.branch.target.history.totalCount :
+            result.defaultBranchRef.target.history.totalCount
+        ),
         color: 'blue'
       }
     case 'tag':
@@ -448,7 +460,8 @@ async function repoStats ({topic, owner, repo, ...restArgs}: PathArgs) {
         color: li ? 'blue' : 'grey'
       }
     case 'last-commit':
-      const commits = result.branch.target.history.nodes
+      const branch = result.branch || result.defaultBranchRef
+      const commits = branch.target.history.nodes
       const lastDate = commits.length && new Date(commits[0].committedDate)
       const fromNow = lastDate && distanceToNow(lastDate, { addSuffix: true })
       return {


### PR DESCRIPTION
Hello! I'm maintaining [awesome-cms](https://github.com/postlight/awesome-cms) at the moment, and we ran into a problem where some of the CMSes we have metadata for changed their default branch from `master` to `main`. This broke a lot of the badges in our list, because badgen simply does a fallback to `master` if no ref is provided. It seemed like an easy fix, so I thought I'd try to do it myself.

This PR makes it so the `github/last-commit` and `github/commits` endpoints will both default to querying using `defaultBranchRef` instead of hardcoding `master` as an assumed default. It maintains the possibility of providing a different ref. This is a built-in feature of [GitHub's GraphQL API](https://docs.github.com/en/graphql/reference/objects). 

This changes functionality in one case, where a hypothetical user didn't provide a ref but wanted the badge to show data for a branch called `master` that was _not_ their default branch. The thought process here would be something like "I want to show the last commit date for our 'master' branch even though it's not the default branch, which is called `main`. I can just leave the `ref` param blank because it defaults to `master`, instead of defaulting to the default branch." In that case, this PR would cause that badge to show the stats for `main` and not `master`. Sorry if that's not clearly explained. I'm not sure if it's a likely case, but I can think of a different solution if someone thinks this breaks expectations.

I've tested this on several repos, and I think it works nicely. It makes it align more with my personal conception of how the service should behave, since I would generally assume that if I don't provide a ref, it would default to the default branch, not an arbitrary branch called `master`. It also makes it easier to show up-to-date badges for repos with regularly changing default branches—a lot of the CMSes we list use version numbers as their default branch name, for example. 

Let me know if there's anything else I can do or any questions you have. I didn't see a contribution guide so if I'm missing anything I'm happy to make updates. Would love to get this change merged in if it seems like a reasonable one. 