### PR TITLE
apm: discontinue service

### DIFF
--- a/api/apm.ts
+++ b/api/apm.ts
@@ -1,62 +1,23 @@
-import millify from 'millify'
-import got from '../libs/got'
-import { version, versionColor } from '../libs/utils'
-import { createBadgenHandler, PathArgs } from '../libs/create-badgen-handler'
+import { createBadgenHandler } from '../libs/create-badgen-handler'
+
+const help = `
+## Discontinued
+
+Read all about GitHub [Sunsetting Atom](https://github.blog/2022-06-08-sunsetting-atom/).
+`
 
 export default createBadgenHandler({
   title: 'Atom Package',
-  examples: {
-    '/apm/v/linter': 'version',
-    '/apm/stars/linter': 'stars',
-    '/apm/license/linter': 'license',
-    '/apm/downloads/linter': 'downloads'
-  },
+  examples: {},
   handlers: {
     '/apm/:topic/:pkg': handler
   }
 })
 
-async function handler ({ topic, pkg }: PathArgs) {
-  const endpoint = `https://atom.io/api/packages/${pkg}`
-  const data = await got(endpoint).json<any>()
-
-  switch (topic) {
-    case 'v':
-    case 'version': {
-      return {
-        subject: `apm`,
-        status: version(data.releases.latest),
-        color: versionColor(data.releases.latest)
-      }
-    }
-    case 'dl':
-    case 'downloads': {
-      return {
-        subject: 'downloads',
-        status: millify(data.downloads),
-        color: 'green'
-      }
-    }
-    case 'license': {
-      return {
-        subject: 'license',
-        status: data.versions[data.releases.latest].license || 'unknown',
-        color: 'blue'
-      }
-    }
-    case 'stars': {
-      return {
-        subject: 'stars',
-        status: millify(data.stargazers_count),
-        color: 'green'
-      }
-    }
-    default: {
-      return {
-        subject: 'apm',
-        status: 'unknown topic',
-        color: 'grey'
-      }
-    }
+async function handler () {
+  return {
+    subject: 'apm',
+    status: 'discontinued',
+    color: 'grey'
   }
 }

--- a/libs/badge-list.ts
+++ b/libs/badge-list.ts
@@ -22,7 +22,6 @@ export const liveBadgeList = [
   'nuget',
   'packagist',
   'rubygems',
-  'apm',
   'hackage',
   'vs-marketplace',
   'melpa',


### PR DESCRIPTION
Following this [discussion](https://github.com/badgen/badgen.net/discussions/584), I'm removing support for `apm`, the package manager for the Atom editor.

Question: Should the service remain listed in `badge-list.ts`?