### PR TITLE
Fix chrome web store users badge

### DIFF
--- a/api/chrome-web-store.ts
+++ b/api/chrome-web-store.ts
@@ -19,7 +19,7 @@ export default createBadgenHandler({
 })
 
 async function handler ({ topic, id }: PathArgs) {
-  const chromeWebStore = await ChromeWebStore.load({ id })
+  const chromeWebStore = await ChromeWebStore.load({ id, qs: { hl: 'en' } })
   switch (topic) {
     case 'v': {
       const v = chromeWebStore.version()


### PR DESCRIPTION
Forcing the chrome web store page to be in English fixes the "users" badge issue #559

```js
const id = 'hpoiflhmfklhfcfpibmdmpeonphmdbda'
const chromeWebStore = await ChromeWebStore.load({ id })
const chromeWebStoreEnglish = await ChromeWebStore.load({ id, qs: { hl: 'en' } })

console.log(chromeWebStore.meta().users) // prints 7
console.log(chromeWebStoreEnglish.meta().users) // prints 7000
```

I realized that this "trick" is not really a trick, as it is actually what's used in the first example of the [webextension-store-meta](https://github.com/awesome-webextension/webextension-store-meta) documentation :upside_down_face: 

> ```js
> const ChromeWebStore = require('webextension-store-meta/lib/chrome-web-store')
> const chromeWebStore = await ChromeWebStore.load({ id: 'xxxxxxx', qs: { hl: 'en' } })
> console.log(chromeWebStore.meta())
> ```

Fixes #559 