### PR TITLE
feat: migrate /hackage badges, and fixes #585

### DIFF
--- a/libs/badge-list.ts
+++ b/libs/badge-list.ts
@@ -20,7 +20,6 @@ export const liveBadgeList = [
   'packagist',
   'rubygems',
   'apm',
-  'hackage',
   'vs-marketplace',
   'melpa',
   'maven',

--- a/libs/badge-list2.ts
+++ b/libs/badge-list2.ts
@@ -2,6 +2,7 @@ import staticBadge from '../pages/api/static'
 import github from '../pages/api/github'
 import npm from '../pages/api/npm'
 import chromeWebStore from '../pages/api/chrome-web-store'
+import hackage from '../pages/api/hackage'
 import pypi from '../pages/api/pypi'
 import runkit from '../pages/api/runkit'
 import winget from '../pages/api/winget'
@@ -12,6 +13,7 @@ export default {
   github: github.meta,
   npm: npm.meta,
   chromeWebStore: chromeWebStore.meta,
+  hackage: hackage.meta,
   pypi: pypi.meta,
   runkit: runkit.meta,
   winget: winget.meta,

--- a/next.config.js
+++ b/next.config.js
@@ -45,6 +45,7 @@ const nextConfig = {
       '/github',
       '/npm',
       '/chrome-web-store',
+      '/hackage',
       '/pypi',
       '/runkit',
       '/winget',

--- a/pages/api/hackage.ts
+++ b/pages/api/hackage.ts
@@ -43,6 +43,7 @@ async function handler ({ topic, pkg }: PathArgs) {
 
 // Naive implementation (only parse meta blocks)
 const parseCabalFile = raw => {
+  // this regex needs to support both v1 and v2 for cabalfile
   const cabalMeta = raw.match(/[\w-]+:.+\S+$/gm).reduce((accu, line) => {
     const [key, value] = line.split(':')
     accu[key.toLowerCase()] = value.trim()

--- a/pages/api/hackage.ts
+++ b/pages/api/hackage.ts
@@ -1,6 +1,6 @@
-import got from '../libs/got'
-import { version as v, versionColor } from '../libs/utils'
-import { createBadgenHandler, PathArgs } from '../libs/create-badgen-handler'
+import got from '../../libs/got'
+import { version as v, versionColor } from '../../libs/utils'
+import { createBadgenHandler, PathArgs } from '../../libs/create-badgen-handler-next'
 
 export default createBadgenHandler({
   title: 'Hackage',
@@ -32,14 +32,22 @@ async function handler ({ topic, pkg }: PathArgs) {
         status: license,
         color: 'blue'
       }
+    default:
+      return {
+        subject: 'hackage',
+        status: 'unknown topic',
+        color: 'grey'
+      }
   }
 }
 
 // Naive implementation (only parse meta blocks)
 const parseCabalFile = raw => {
-  return raw.match(/[\w-]+:.+\S+$/gm).reduce((accu, line) => {
+  const cabalMeta = raw.match(/[\w-]+:.+\S+$/gm).reduce((accu, line) => {
     const [key, value] = line.split(':')
-    accu[key] = value.trim()
+    accu[key.toLowerCase()] = value.trim()
     return accu
   }, {})
+
+  return cabalMeta
 }

--- a/vercel.json
+++ b/vercel.json
@@ -111,10 +111,6 @@
       "destination": "https://v2022.badgen.net/gitter/:match*"
     },
     {
-      "source": "/hackage/:match*",
-      "destination": "https://v2022.badgen.net/hackage/:match*"
-    },
-    {
       "source": "/haxelib/:match*",
       "destination": "https://v2022.badgen.net/haxelib/:match*"
     },


### PR DESCRIPTION
The broken badge is caused by updated cabal file version (v2.x)

Fixed preview https://badgennet-git-migrate-hackage-badgen.vercel.app/hackage/v/BNFC