### PR TITLE
Fix license parsing

### DIFF
--- a/api-/pub.ts
+++ b/api-/pub.ts
@@ -102,7 +102,7 @@ async function webHandler({ topic, pkg }: PathArgs) {
 
   switch (topic) {
     case 'license': {
-      const license = html.match(/License<\/h3>\s*<p>([^(]+)\(/i)?.[1].trim()
+      const license = html.match(/License<\/h3>\s*<p>[^>]+>([^(]+)\(/i)?.[1].trim()
       return {
         subject: 'license',
         status: license || 'unknown',


### PR DESCRIPTION
Should fix broken license badges such as `https://badgen.net/pub/license/pubx`, as suggested in #557 (thanks @lastarc)

![License](https://badgen.net/pub/license/pubx)

Fixes  #557