### PR TITLE
fix: support for external icon. fix #570

### DIFF
--- a/libs/fetch-icon.ts
+++ b/libs/fetch-icon.ts
@@ -1,6 +1,6 @@
 import got from 'got'
 
-export default async function (iconUrl) {
+export default async function (iconUrl: string) {
   return got(iconUrl).then(res => {
     const type = res.headers['content-type']
     if (!type!.startsWith('image')) { return }
@@ -8,5 +8,5 @@ export default async function (iconUrl) {
     const base64 = Buffer.from(res.body).toString('base64')
     const encoded = `data:${type};base64,${base64}`
     return encoded
-  }).catch(err => undefined)
+  }).catch(() => undefined)
 }


### PR DESCRIPTION
External icon is back:
https://badgennet-git-external-icon-badgen.vercel.app/static/OpenAI/GPT-4?icon=https://simpleicons.vercel.app/openai/fff&label