### PR TITLE
fix: Change simpleicons twitter --> x to resolve icon render

### DIFF
--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -32,7 +32,7 @@ export default function Footer () {
         </div>
         <div className='links'>
           <a title='badgen twitter link' href='https://twitter.com/badgen_net'>
-            <img alt='badgen twitter link' src='https://simpleicons.vercel.app/twitter/fff' width='30' height='30' />
+            <img alt='badgen twitter link' src='https://simpleicons.vercel.app/x/fff' width='30' height='30' />
           </a>
 
           <a href='https://github.com/badgen/badgen.net'>

--- a/libs/serve-doc-next.ts
+++ b/libs/serve-doc-next.ts
@@ -110,7 +110,7 @@ const helpFooter = `
       </div>
       <div class='links'>
         <a href='https://twitter.com/badgen_net'>
-          <img src='https://simpleicons.now.sh/twitter/fff' />
+          <img src='https://simpleicons.now.sh/x/fff' />
         </a>
         <a href='https://github.com/badgen/badgen.net'>
           <img src='https://simpleicons.now.sh/github/fff' />

--- a/libs/serve-doc.ts
+++ b/libs/serve-doc.ts
@@ -106,7 +106,7 @@ const helpFooter = `
       </div>
       <div class='links'>
         <a href='https://twitter.com/badgen_net'>
-          <img src='https://simpleicons.now.sh/twitter/fff' />
+          <img src='https://simpleicons.now.sh/x/fff' />
         </a>
         <a href='https://github.com/badgen/badgen.net'>
           <img src='https://simpleicons.now.sh/github/fff' />


### PR DESCRIPTION
## `Fix`
Image src coming from `simpleicons`  for `/twitter`  wasn't reendering a twitter icon in the `serve-doc` and `serve-doc-next` footer.

<details>
<summary>Screenshots</summary>

### Before

<img width="625" alt="image" src="https://github.com/user-attachments/assets/26fc7d7e-26d8-46b7-a80f-3dd474ee5db3">

### After

<img width="625" alt="image" src="https://github.com/user-attachments/assets/f3b43e5f-09bf-43b8-b689-d36154ec6095">

</details>