### PR TITLE
feat(pub): add monthly downloads endpoint

### DIFF
--- a/pages/api/pub.ts
+++ b/pages/api/pub.ts
@@ -15,13 +15,14 @@ export default createBadgenHandler({
     '/pub/likes/firebase_core': 'likes',
     '/pub/points/rxdart': 'pub points',
     '/pub/popularity/mobx': 'popularity',
+    '/pub/dm/riverpod': 'monthly downloads',
     '/pub/sdk-version/uuid': 'sdk-version',
     '/pub/dart-platform/rxdart': 'dart-platform',
     '/pub/dart-platform/google_sign_in': 'dart-platform',
     '/pub/flutter-platform/xml': 'flutter-platform'
   },
   handlers: {
-    '/pub/:topic<v|version|sdk-version|likes|points|popularity|dart-platform|flutter-platform>/:pkg': apiHandler,
+    '/pub/:topic<v|version|sdk-version|likes|points|popularity|dm|dart-platform|flutter-platform>/:pkg': apiHandler,
     '/pub/:topic<license>/:pkg': licenseHandler
   }
 })
@@ -73,6 +74,14 @@ async function apiHandler ({ topic, pkg }: PathArgs) {
       return {
         subject: 'popularity',
         status: `${Math.round(percentage)}%`,
+        color: 'green'
+      }
+    }
+    case 'dm': {
+      const { downloadCount30Days } = await client.get(`packages/${pkg}/score`).json<any>()
+      return {
+        subject: 'downloads',
+        status: millify(downloadCount30Days) + '/month',
         color: 'green'
       }
     }


### PR DESCRIPTION
[![pub-dm](https://github.com/user-attachments/assets/c70baa00-b8f2-48e1-b0b8-b7946fdcacff)](https://pub.dev/packages/riverpod/score)
(e.g. `https://badgen.net/pub/dm/riverpod`)

- Introduced a new endpoint for monthly downloads under '/pub/dm/:pkg'.
- Updated the apiHandler to handle the new 'dm' topic for fetching download counts.