### PR TITLE
Allow Gitlab badge requests without a token

### DIFF
--- a/libs/gitlab.ts
+++ b/libs/gitlab.ts
@@ -1,14 +1,14 @@
 import got from './got'
-import { BadgenError } from './create-badgen-handler'
 
 const rand = <T>(arr: T[]): T => arr[Math.floor(Math.random() * arr.length)]
 
 
 // request gitlab api v4 (graphql)
 export function queryGitlab<T = any>(query) {
+  const token = pickGitlabToken(); 
   const headers = {
-    authorization: `Bearer ${pickGitlabToken()}`,
-  }
+    authorization: token ? `Bearer ${token}` : undefined,
+  };
   const json = { query }
   const endpoint =
     process.env.GITLAB_API_GRAPHQL || 'https://gitlab.com/api/graphql'
@@ -16,9 +16,10 @@ export function queryGitlab<T = any>(query) {
 }
 
 export function restGitlab<T = any>(path: string, fullResponse = false) {
+  const token = pickGitlabToken(); 
   const headers = {
-    authorization: `Bearer ${pickGitlabToken()}`,
-  }
+    authorization: token ? `Bearer ${token}` : undefined,
+  };
   const prefixUrl = process.env.GITLAB_API || 'https://gitlab.com/api/v4'
   return fullResponse ? got.get(path, { prefixUrl, headers }) : got.get(path, { prefixUrl, headers }).json<T>()
 }
@@ -26,7 +27,7 @@ export function restGitlab<T = any>(path: string, fullResponse = false) {
 function pickGitlabToken() {
   const { GITLAB_TOKENS } = process.env
   if (!GITLAB_TOKENS) {
-    throw new BadgenError({ status: 'token required' })
+    return null;
   }
   const tokens = GITLAB_TOKENS.split(',').map(segment => segment.trim())
   return rand(tokens)


### PR DESCRIPTION
For a while now, the GitLab badges have not been working because the tokens has expired. 

During testing, I discovered that no token is required for public API calls, so I made tokens optional.

@amio it would be nice if you could refresh the Gitlab tokens or merge this PR and remove the tokens.

Fixes: #678
