### PR TITLE
Use BadgenError from Next handler

### DIFF
--- a/libs/docker.ts
+++ b/libs/docker.ts
@@ -1,5 +1,5 @@
 import got from './got'
-import { BadgenError } from './create-badgen-handler'
+import { BadgenError } from './create-badgen-handler-next'
 
 // request image specific DockerHub pull token
 export function getDockerAuthToken<T = any>(scope: string, name: string) {

--- a/libs/github.ts
+++ b/libs/github.ts
@@ -1,5 +1,5 @@
 import got from './got'
-import { BadgenError } from './create-badgen-handler'
+import { BadgenError } from './create-badgen-handler-next'
 
 const rand = <T>(arr: T[]): T => arr[Math.floor(Math.random() * arr.length)]
 

--- a/libs/gitlab.ts
+++ b/libs/gitlab.ts
@@ -1,5 +1,5 @@
 import got from './got'
-import { BadgenError } from './create-badgen-handler'
+import { BadgenError } from './create-badgen-handler-next'
 
 const rand = <T>(arr: T[]): T => arr[Math.floor(Math.random() * arr.length)]
 


### PR DESCRIPTION
I'm not sure when the Next-handler and when the legacy handler are used, but when I run it locally, it uses the Next-handler. 

When for example no Github token is set, it doesn't use the correct `BadgenError` from `create-badgen-handler-next` which causes the handler to fail because `error.message` is undefined and that is not allowed for `setHeader`.

https://github.com/badgen/badgen.net/blob/861a20a29de85382b26b17f5fc911620a4853457/libs/create-badgen-handler-next.ts#L104

https://github.com/badgen/badgen.net/blob/861a20a29de85382b26b17f5fc911620a4853457/libs/github.ts#L33