### PR TITLE
Fix codecov for Gitlab and change examples to new url

### DIFF
--- a/pages/api/codecov.ts
+++ b/pages/api/codecov.ts
@@ -5,12 +5,12 @@ import { createBadgenHandler, PathArgs } from '../../libs/create-badgen-handler-
 export default createBadgenHandler({
   title: 'CodeCov',
   examples: {
-    '/codecov/c/github/babel/babel': 'coverage (github)',
-    '/codecov/c/github/babel/babel/6.x': 'coverage (github, branch)',
-    '/codecov/c/bitbucket/ignitionrobotics/ign-math': 'coverage (bitbucket)',
-    '/codecov/c/bitbucket/ignitionrobotics/ign-math/master': 'coverage (bitbucket, branch)',
-    '/codecov/c/gitlab/gitlab-org/gitaly': 'coverage (gitlab)',
-    '/codecov/c/gitlab/gitlab-org/gitaly/master': 'coverage (gitlab, branch)'
+    '/codecov/github/babel/babel': 'coverage (github)',
+    '/codecov/github/babel/babel/6.x': 'coverage (github, branch)',
+    '/codecov/bitbucket/ignitionrobotics/ign-math': 'coverage (bitbucket)',
+    '/codecov/bitbucket/ignitionrobotics/ign-math/master': 'coverage (bitbucket, branch)',
+    '/codecov/gitlab/gitlab-org/gitaly': 'coverage (gitlab)',
+    '/codecov/gitlab/gitlab-org/gitaly/master': 'coverage (gitlab, branch)'
   },
   handlers: {
     '/codecov/c/:vcs<github|bitbucket|gitlab>/:owner/:repo/:branch?': handler, // legacy urls
@@ -19,7 +19,7 @@ export default createBadgenHandler({
 })
 
 async function handler ({ vcs, owner, repo, branch }: PathArgs) {
-  const endpoint = `https://codecov.io/api/v2/${vcs}/${owner}/repos/${repo}/report`
+  const endpoint = `https://codecov.io/api/v2/${vcs}/${owner}/repos/${repo}?format=json`
 
   const data = await got(endpoint).json<any>()
 


### PR DESCRIPTION
Fixes: #664

Old request: https://api.codecov.io/api/v2/gitlab/gitlab-org/repos/gitaly/report
New request: https://api.codecov.io/api/v2/gitlab/gitlab-org/repos/gitaly?format=json

<img width="1404" height="470" alt="grafik" src="https://github.com/user-attachments/assets/e0aa5406-751a-4eb6-8ae2-3248a5b0d57d" />
