### PR TITLE
deps: bump webextension-store-meta from 1.2.7 to 1.2.10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "serve-handler": "^6.1.6",
         "serve-marked": "^4.0.0",
         "url-parse": "^1.5.9",
-        "webextension-store-meta": "^1.2.7",
+        "webextension-store-meta": "^1.2.10",
         "yaml": "^2.1.0"
       },
       "devDependencies": {
@@ -5650,6 +5650,17 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/pretty-bytes": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-6.1.1.tgz",
+      "integrity": "sha512-mQUvGU6aUFQ+rNvTIAcZuWGRT9a6f6Yrg9bHs4ImKF+HZCEK+plBvnAZYSIQztknZF2qnzNtr6F8s0+IuptdlQ==",
+      "engines": {
+        "node": "^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/progress": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
@@ -6877,12 +6888,13 @@
       }
     },
     "node_modules/webextension-store-meta": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/webextension-store-meta/-/webextension-store-meta-1.2.7.tgz",
-      "integrity": "sha512-tZC7wUhfbbGFSbIOwTov7R+pKUy+jfj8oUubHCyUFwJhV4UJJ0CvdzJqfVS8iBNBeyT1vzPnxT4eW1vFStRFpQ==",
+      "version": "1.2.10",
+      "resolved": "https://registry.npmjs.org/webextension-store-meta/-/webextension-store-meta-1.2.10.tgz",
+      "integrity": "sha512-i6YelIlbKejvbBQYk/SxyJ2c80lwkRD+E4C5MKPShLeYxpqC+rYoydD12PGgTwv8od+LXgLkXLSrk+fw8Omusw==",
       "dependencies": {
         "domhandler": "^4.0.0",
         "htmlparser2": "^6.1.0",
+        "pretty-bytes": "^6.1.1",
         "undici": "^6.11.1"
       },
       "engines": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "serve-handler": "^6.1.6",
     "serve-marked": "^4.0.0",
     "url-parse": "^1.5.9",
-    "webextension-store-meta": "^1.2.7",
+    "webextension-store-meta": "^1.2.10",
     "yaml": "^2.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
[CHANGELOG](https://github.com/awesome-webextension/webextension-store-meta/blob/v1.2.10/CHANGELOG.md)

Highlights:

- Support new Firefox Add-ons Store info.
- Add null check for extension not found in ChromeWebStore.