### PR TITLE
Add Codeberg support

### DIFF
--- a/libs/badge-list.ts
+++ b/libs/badge-list.ts
@@ -3,12 +3,12 @@ import staticBadges from '../pages/api/static'
 
 const rel = (...args) => path.resolve(__dirname, ...args)
 
+/** @deprecated use badge-list2.ts instead */
 // sort live badge manually
 export const liveBadgeList = [
   // // source control
   // 'github',
   // 'gitlab',
-  'codeberg',
   // release registries
   'homebrew',
   'nuget',

--- a/libs/badge-list.ts
+++ b/libs/badge-list.ts
@@ -8,6 +8,7 @@ export const liveBadgeList = [
   // // source control
   // 'github',
   // 'gitlab',
+  'codeberg',
   // release registries
   'homebrew',
   'nuget',

--- a/libs/badge-list2.ts
+++ b/libs/badge-list2.ts
@@ -1,6 +1,7 @@
 import staticBadge from '../pages/api/static'
 import github from '../pages/api/github'
 import gitlab from '../pages/api/gitlab'
+import codeberg from '../pages/api/codeberg'
 import https from '../pages/api/https'
 import memo from '../pages/api/memo'
 import amo from '../pages/api/amo'
@@ -68,6 +69,7 @@ export default {
   static: staticBadge.meta,
   github: github.meta,
   gitlab: gitlab.meta,
+  codeberg: codeberg.meta,
   https: https.meta,
   memo: memo.meta,
   amo: amo.meta,

--- a/libs/codeberg.ts
+++ b/libs/codeberg.ts
@@ -1,0 +1,22 @@
+import got from './got'
+
+const rand = <T>(arr: T[]): T => arr[Math.floor(Math.random() * arr.length)]
+
+export function restCodeberg<T = any>(path: string, fullResponse = false) {
+  const token = pickCodebergToken()
+  const headers = token ? {
+    authorization: `token ${token}`,
+  } : {}
+  const prefixUrl = 'https://codeberg.org/api/v1'
+  const response = got.get(path, { prefixUrl, headers })
+  return fullResponse ? response : response.json<T>()
+}
+
+function pickCodebergToken() {
+  const { CODEBERG_TOKENS } = process.env
+  if (!CODEBERG_TOKENS) {
+    return null
+  }
+  const tokens = CODEBERG_TOKENS.split(',').map(segment => segment.trim())
+  return rand(tokens)
+}

--- a/next.config.js
+++ b/next.config.js
@@ -26,6 +26,7 @@ const nextConfig = {
       '/static',
       '/github',
       '/gitlab',
+      '/codeberg',
       '/https',
       '/memo',
       // registry

--- a/pages/api/codeberg.ts
+++ b/pages/api/codeberg.ts
@@ -1,0 +1,139 @@
+import { formatDistanceToNow } from 'date-fns/formatDistanceToNow'
+import { createBadgenHandler, PathArgs } from 'libs/create-badgen-handler-next'
+import { restCodeberg } from 'libs/codeberg'
+import { millify, version } from 'libs/utils'
+
+export default createBadgenHandler({
+  title: 'Codeberg',
+  examples: {
+    '/codeberg/stars/forgejo/forgejo': 'stars',
+    '/codeberg/forks/forgejo/forgejo': 'forks',
+    '/codeberg/issues/forgejo/forgejo': 'issues',
+    '/codeberg/open-issues/forgejo/forgejo': 'open issues',
+    '/codeberg/closed-issues/forgejo/forgejo': 'closed issues',
+    '/codeberg/prs/forgejo/forgejo': 'PRs',
+    '/codeberg/open-prs/forgejo/forgejo': 'open PRs',
+    '/codeberg/closed-prs/forgejo/forgejo': 'closed PRs',
+    '/codeberg/releases/forgejo/forgejo': 'releases',
+    '/codeberg/release/forgejo/forgejo': 'latest release',
+    '/codeberg/tags/forgejo/forgejo': 'tags',
+    '/codeberg/commits/forgejo/forgejo': 'commits count',
+    '/codeberg/commits/forgejo/forgejo/forgejo': 'commits count (branch ref)',
+    '/codeberg/last-commit/forgejo/forgejo': 'last commit',
+    '/codeberg/last-commit/forgejo/forgejo/forgejo': 'last commit (branch ref)',
+  },
+  handlers: {
+    '/codeberg/:topic<stars|forks|issues|open-issues|closed-issues|prs|open-prs|closed-prs|releases|release|tags|commits|last-commit>/:owner/:repo/:ref?': handler,
+  }
+})
+
+async function handler({ topic, owner, repo, ref }: PathArgs) {
+  switch (topic) {
+    case 'stars':
+    case 'forks':
+    case 'issues': // open-issues in Codeberg/Gitea repo API
+    case 'open-issues': {
+      const repoData = await restCodeberg(`repos/${owner}/${repo}`)
+      if (topic === 'stars') {
+        return {
+          subject: 'stars',
+          status: millify(repoData.stars_count),
+          color: 'blue'
+        }
+      } else if (topic === 'forks') {
+        return {
+          subject: 'forks',
+          status: millify(repoData.forks_count),
+          color: 'blue'
+        }
+      } else {
+        return {
+          subject: 'open issues',
+          status: millify(repoData.open_issues_count),
+          color: repoData.open_issues_count === 0 ? 'green' : 'orange'
+        }
+      }
+    }
+    case 'closed-issues': {
+      const res = await restCodeberg(`repos/${owner}/${repo}/issues?state=closed&type=issues&limit=1`, true)
+      return {
+        subject: 'closed issues',
+        status: millify(parseInt(res.headers['x-total-count'] || '0')),
+        color: 'blue'
+      }
+    }
+    case 'prs': {
+      const res = await restCodeberg(`repos/${owner}/${repo}/pulls?state=all&limit=1`, true)
+      return {
+        subject: 'PRs',
+        status: millify(parseInt(res.headers['x-total-count'] || '0')),
+        color: 'blue'
+      }
+    }
+    case 'open-prs': {
+      const res = await restCodeberg(`repos/${owner}/${repo}/pulls?state=open&limit=1`, true)
+      return {
+        subject: 'open PRs',
+        status: millify(parseInt(res.headers['x-total-count'] || '0')),
+        color: 'blue'
+      }
+    }
+    case 'closed-prs': {
+      const res = await restCodeberg(`repos/${owner}/${repo}/pulls?state=closed&limit=1`, true)
+      return {
+        subject: 'closed PRs',
+        status: millify(parseInt(res.headers['x-total-count'] || '0')),
+        color: 'blue'
+      }
+    }
+    case 'releases': {
+      const res = await restCodeberg(`repos/${owner}/${repo}/releases?limit=1`, true)
+      return {
+        subject: 'releases',
+        status: millify(parseInt(res.headers['x-total-count'] || '0')),
+        color: 'blue'
+      }
+    }
+    case 'release': {
+      const releases = await restCodeberg(`repos/${owner}/${repo}/releases?limit=1`)
+      const latest = releases[0]
+      return {
+        subject: 'release',
+        status: latest ? version(latest.name || latest.tag_name) : 'none',
+        color: 'blue'
+      }
+    }
+    case 'tags': {
+      const res = await restCodeberg(`repos/${owner}/${repo}/tags?limit=1`, true)
+      return {
+        subject: 'tags',
+        status: millify(parseInt(res.headers['x-total-count'] || '0')),
+        color: 'blue'
+      }
+    }
+    case 'commits': {
+      const res = await restCodeberg(`repos/${owner}/${repo}/commits?limit=1${ref ? `&sha=${ref}` : ''}`, true)
+      return {
+        subject: 'commits',
+        status: millify(parseInt(res.headers['x-total-count'] || '0')),
+        color: 'blue'
+      }
+    }
+    case 'last-commit': {
+      const commits = await restCodeberg(`repos/${owner}/${repo}/commits?limit=1${ref ? `&sha=${ref}` : ''}`)
+      const lastDate = commits.length && new Date(commits[0].commit.committer.date)
+      const fromNow = lastDate && formatDistanceToNow(lastDate, { addSuffix: true })
+      return {
+        subject: 'last commit',
+        status: fromNow || 'none',
+        color: 'green'
+      }
+    }
+    default:
+      return {
+        subject: 'codeberg',
+        status: 'unknown topic',
+        color: 'grey'
+      }
+  }
+}

--- a/test/e2e.test.mjs
+++ b/test/e2e.test.mjs
@@ -38,6 +38,52 @@ test('/memo: update "depoyed" badge', async (t) => {
     assert.deepEqual(result, { status, label, color })
 })
 
+
+test('/codeberg/stars/forgejo/forgejo', async (t) => {
+    const badgeURL = `${BASE_URL}/codeberg/stars/forgejo/forgejo`
+    const response = await fetch(badgeURL)
+
+    assert.strictEqual(response.status, 200)
+    assert.strictEqual(response.headers.get('content-type'), 'image/svg+xml;charset=utf-8')
+})
+
+
+test('/codeberg/issues/forgejo/forgejo', async (t) => {
+    const badgeURL = `${BASE_URL}/codeberg/issues/forgejo/forgejo`
+    const response = await fetch(badgeURL)
+
+    assert.strictEqual(response.status, 200)
+    assert.strictEqual(response.headers.get('content-type'), 'image/svg+xml;charset=utf-8')
+})
+
+
+test('/codeberg/commits/forgejo/forgejo', async (t) => {
+    const badgeURL = `${BASE_URL}/codeberg/commits/forgejo/forgejo`
+    const response = await fetch(badgeURL)
+
+    assert.strictEqual(response.status, 200)
+    assert.strictEqual(response.headers.get('content-type'), 'image/svg+xml;charset=utf-8')
+})
+
+
+test('/codeberg/prs/forgejo/forgejo', async (t) => {
+    const badgeURL = `${BASE_URL}/codeberg/prs/forgejo/forgejo`
+    const response = await fetch(badgeURL)
+
+    assert.strictEqual(response.status, 200)
+    assert.strictEqual(response.headers.get('content-type'), 'image/svg+xml;charset=utf-8')
+})
+
+
+test('/codeberg/release/forgejo/forgejo', async (t) => {
+    const badgeURL = `${BASE_URL}/codeberg/release/forgejo/forgejo`
+    const response = await fetch(badgeURL)
+
+    assert.strictEqual(response.status, 200)
+    assert.strictEqual(response.headers.get('content-type'), 'image/svg+xml;charset=utf-8')
+})
+
+
 function getGitLastCommitDate () {
     const lastCommitDateString = execSync('git log -1 --format=%cI').toString().trim()
     return extractBareDate(lastCommitDateString)


### PR DESCRIPTION
Support for codeberg.org badges has been implemented. This includes a variety of metrics such as stars, forks, issues, pull requests, releases, tags, and commit data. The implementation leverages the Codeberg (Gitea/Forgejo) API and includes comprehensive E2E tests and documentation examples.

---
*PR created automatically by Jules for task [71452159505630164](https://jules.google.com/task/71452159505630164) started by @amio*