### PR TITLE
Support arbitrary sub-file paths for BundleJS badges

### DIFF
--- a/pages/api/bundlejs.ts
+++ b/pages/api/bundlejs.ts
@@ -9,10 +9,11 @@ export default createBadgenHandler({
     '/bundlejs/min/react': 'minified',
     '/bundlejs/minzip/react': 'minified + gzip',
     '/bundlejs/minzip/@noble/hashes': '(scoped pkg) minified + gzip',
+    '/bundlejs/minzip/@noble/hashes/sha3.js': '(scoped pkg) minified + gzip (sub-path)',
   },
   handlers: {
-    '/bundlejs/:topic/:scope<@.*>/:name': handler,
-    '/bundlejs/:topic/:name': handler,
+    '/bundlejs/:topic/:scope<@.*>/:name+': handler,
+    '/bundlejs/:topic/:name+': handler,
   }
 })
 


### PR DESCRIPTION
This change enables the `bundlejs` badge service to support arbitrary sub-file paths in package names (e.g., `@noble/hashes/sha3.js`). 

I updated the route patterns in `pages/api/bundlejs.ts` to use `:name+` instead of `:name` for both scoped and non-scoped packages. I also added a new example to the service metadata to showcase this feature.

Verification:
1. Started the dev server and used `curl` to request a badge with a sub-path (`/bundlejs/minzip/@noble/hashes/sha3.js`).
2. Confirmed via logs that the package name was correctly extracted as `@noble/hashes/sha3.js`.
3. Ran the project's test suite and end-to-end tests, all of which passed.
4. Reverted accidental changes to `next-env.d.ts` that occurred during local development.

---
*PR created automatically by Jules for task [15938144163441773012](https://jules.google.com/task/15938144163441773012) started by @amio*