### PR TITLE
feat: add Edge Add-ons badges

### DIFF
--- a/libs/badge-list2.ts
+++ b/libs/badge-list2.ts
@@ -20,6 +20,7 @@ import coveralls from '../pages/api/coveralls'
 import travis from '../pages/api/travis'
 import circleci from '../pages/api/circleci'
 import chromeWebStore from '../pages/api/chrome-web-store'
+import edgeAddons from '../pages/api/edge-addons'
 import vsMarketplace from '../pages/api/vs-marketplace'
 import openVsx from '../pages/api/open-vsx'
 import hackage from '../pages/api/hackage'
@@ -82,6 +83,7 @@ export default {
   docker: docker.meta,
   'open-vsx': openVsx.meta,
   'chrome-web-store': chromeWebStore.meta,
+  'edge-addons': edgeAddons.meta,
   'vs-marketplace': vsMarketplace.meta,
   hackage: hackage.meta,
   pypi: pypi.meta,

--- a/next.config.js
+++ b/next.config.js
@@ -35,6 +35,7 @@ const nextConfig = {
       '/docker',
       '/open-vsx',
       '/chrome-web-store',
+      '/edge-addons',
       '/vs-marketplace',
       '/hackage',
       '/ppm',

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "serve-marked": "^5.0.0",
         "simple-icons": "^16.18.1",
         "url-parse": "^1.5.10",
-        "webextension-store-meta": "^1.2.10",
+        "webextension-store-meta": "^1.3.0",
         "yaml": "^2.8.4"
       },
       "devDependencies": {
@@ -5686,12 +5686,12 @@
       }
     },
     "node_modules/pretty-bytes": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-6.1.1.tgz",
-      "integrity": "sha512-mQUvGU6aUFQ+rNvTIAcZuWGRT9a6f6Yrg9bHs4ImKF+HZCEK+plBvnAZYSIQztknZF2qnzNtr6F8s0+IuptdlQ==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-7.1.0.tgz",
+      "integrity": "sha512-nODzvTiYVRGRqAOvE84Vk5JDPyyxsVk0/fbA/bq7RqlnhksGpset09XTxbpvLTIjoaF7K8Z8DG8yHtKGTPSYRw==",
       "license": "MIT",
       "engines": {
-        "node": "^14.13.1 || >=16.0.0"
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -6415,14 +6415,14 @@
       }
     },
     "node_modules/webextension-store-meta": {
-      "version": "1.2.10",
-      "resolved": "https://registry.npmjs.org/webextension-store-meta/-/webextension-store-meta-1.2.10.tgz",
-      "integrity": "sha512-i6YelIlbKejvbBQYk/SxyJ2c80lwkRD+E4C5MKPShLeYxpqC+rYoydD12PGgTwv8od+LXgLkXLSrk+fw8Omusw==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/webextension-store-meta/-/webextension-store-meta-1.3.0.tgz",
+      "integrity": "sha512-VQc5Wyvrndh+GmI20DUcVXWNfPH3f2t+XwXLGMnv/lgH6bdmFoahG1o3w55sr2Ct7+ngbOxMkSFdGRmG46UciA==",
       "license": "MIT",
       "dependencies": {
         "domhandler": "^4.0.0",
         "htmlparser2": "^6.1.0",
-        "pretty-bytes": "^6.1.1",
+        "pretty-bytes": "^7.1.0",
         "undici": "^6.11.1"
       },
       "engines": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "serve-marked": "^5.0.0",
     "simple-icons": "^16.18.1",
     "url-parse": "^1.5.10",
-    "webextension-store-meta": "^1.2.10",
+    "webextension-store-meta": "^1.3.0",
     "yaml": "^2.8.4"
   },
   "devDependencies": {

--- a/pages/api/edge-addons.ts
+++ b/pages/api/edge-addons.ts
@@ -1,0 +1,79 @@
+import millify from 'millify'
+import EdgeAddons from 'webextension-store-meta/lib/edge-addons'
+import { version, versionColor, stars } from '../../libs/utils'
+import { createBadgenHandler, PathArgs } from '../../libs/create-badgen-handler-next'
+
+const subject = 'edge add-ons'
+
+export default createBadgenHandler({
+  title: 'Edge Add-ons',
+  examples: {
+    '/edge-addons/v/cnlefmmeadmemmdciolhbnfeacpdfbkd': 'version',
+    '/edge-addons/users/cnlefmmeadmemmdciolhbnfeacpdfbkd': 'users',
+    '/edge-addons/stars/cnlefmmeadmemmdciolhbnfeacpdfbkd': 'stars',
+    '/edge-addons/rating/cnlefmmeadmemmdciolhbnfeacpdfbkd': 'rating',
+    '/edge-addons/rating-count/cnlefmmeadmemmdciolhbnfeacpdfbkd': 'rating count',
+  },
+  handlers: {
+    '/edge-addons/:topic<v|users|stars|rating|rating-count>/:id': handler
+  }
+})
+
+async function handler ({ topic, id }: PathArgs) {
+  const result = await EdgeAddons.load({ id, qs: { hl: 'en-US' } }).catch(console.error)
+
+  if (!result || !result.url()) {
+    return {
+      subject,
+      status: 'not found',
+      color: 'grey',
+    }
+  }
+
+  switch (topic) {
+    case 'v': {
+      const v = result.version()
+      return {
+        subject,
+        status: version(v),
+        color: v ? versionColor(v) : 'grey'
+      }
+    }
+    case 'users': {
+      const users = result.activeInstallCount()
+      return {
+        subject: 'users',
+        status: users === null ? 'unknown' : millify(users),
+        color: 'green'
+      }
+    }
+    case 'rating': {
+      const rating = result.averageRating()
+      return {
+        subject: 'rating',
+        status: `${rating === null ? '-' : rating.toFixed(1)}/5`,
+        color: 'green'
+      }
+    }
+    case 'stars':
+      return {
+        subject: 'stars',
+        status: stars(result.averageRating() || 0),
+        color: 'green'
+      }
+    case 'rating-count': {
+      const ratingCount = result.ratingCount()
+      return {
+        subject: 'rating count',
+        status: ratingCount === null ? 'unknown' : `${millify(ratingCount)} total`,
+        color: 'green'
+      }
+    }
+    default:
+      return {
+        subject,
+        status: 'unknown',
+        color: 'grey'
+      }
+  }
+}

--- a/public/badges.md
+++ b/public/badges.md
@@ -272,6 +272,16 @@ Metadata associated with an image in the [label-schema](http://label-schema.org/
 - [rating](https://badgen.net/chrome-web-store/rating/ckkdlimhmcjmikdlpkmbgfkaikojcbjk)
 - [rating count](https://badgen.net/chrome-web-store/rating-count/ckkdlimhmcjmikdlpkmbgfkaikojcbjk)
 
+## Edge Add-ons
+
+### Examples
+
+- [version](https://badgen.net/edge-addons/v/cnlefmmeadmemmdciolhbnfeacpdfbkd)
+- [users](https://badgen.net/edge-addons/users/cnlefmmeadmemmdciolhbnfeacpdfbkd)
+- [stars](https://badgen.net/edge-addons/stars/cnlefmmeadmemmdciolhbnfeacpdfbkd)
+- [rating](https://badgen.net/edge-addons/rating/cnlefmmeadmemmdciolhbnfeacpdfbkd)
+- [rating count](https://badgen.net/edge-addons/rating-count/cnlefmmeadmemmdciolhbnfeacpdfbkd)
+
 ## Visual Studio Marketplace
 
 ### Examples


### PR DESCRIPTION
Add Edge Add-ons badge endpoints for version, users, stars, rating, and rating count using webextension-store-meta.

Closes #696