### PR TITLE
chore: rename AMO badge label to Firefox Add-ons

### DIFF
--- a/pages/api/amo.ts
+++ b/pages/api/amo.ts
@@ -3,7 +3,7 @@ import { millify, stars, version, versionColor } from '../../libs/utils'
 import { createBadgenHandler, PathArgs } from '../../libs/create-badgen-handler-next'
 
 export default createBadgenHandler({
-  title: 'Mozilla Add-on',
+  title: 'Firefox Add-ons',
   examples: {
     '/amo/v/markdown-viewer-chrome': 'version',
     '/amo/users/markdown-viewer-chrome': 'users',
@@ -23,7 +23,7 @@ async function handler ({ topic, name }: PathArgs) {
   switch (topic) {
     case 'v':
       return {
-        subject: 'mozilla add-on',
+        subject: 'firefox add-ons',
         status: version(addon.current_version.version),
         color: versionColor(addon.current_version.version)
       }
@@ -53,7 +53,7 @@ async function handler ({ topic, name }: PathArgs) {
       }
     default:
       return {
-        subject: 'mozilla add-on',
+        subject: 'firefox add-ons',
         status: 'unknown',
         color: 'grey'
       }

--- a/public/badges.md
+++ b/public/badges.md
@@ -166,7 +166,7 @@ To keep a memo badge, you need to update the badge at least on a monthly basis. 
 
 - [memoized badge for deploy status](https://badgen.net/memo/deployed)
 
-## Mozilla Add-on
+## Firefox Add-ons
 
 ### Examples
 


### PR DESCRIPTION
See #778.

This keeps the label simple and consistent with other services.