### PR TITLE
refactor: millify Chrome Web Store user count

### DIFF
--- a/pages/api/chrome-web-store.ts
+++ b/pages/api/chrome-web-store.ts
@@ -40,7 +40,7 @@ async function handler ({ topic, id }: PathArgs) {
     case 'users':
       return {
         subject: 'users',
-        status: result.users(),
+        status: millify(parseInt(result.users()?.replace(/,/g, '') || '0')),
         color: 'green'
       }
     case 'price':


### PR DESCRIPTION
Format Chrome Web Store user counts with `millify`, so values render consistently with other count badges.


I also noticed that `.nvmrc` is still set to Node.js 18, while `package.json` requires Node.js `>=24`. Should `.nvmrc` be updated to match the engine requirement?
