### PR TITLE
feat: add total release assets download count via /assets-dl/:owner/:repo/total

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@ node_modules
 .next
 .meta
 .env
+.env*.local
+.env.*
+next-env.d.ts
 
 # Sentry
 .sentryclirc

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,0 @@
-/// <reference types="next" />
-/// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
-
-// NOTE: This file should not be edited
-// see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.

--- a/pages/api/github.ts
+++ b/pages/api/github.ts
@@ -48,7 +48,7 @@ export default createBadgenHandler({
     '/github/last-commit/micromatch/micromatch/4.0.1': 'last commit (tag ref)',
     '/github/assets-dl/electron/electron': 'assets downloads for latest release',
     '/github/assets-dl/electron/electron/v7.0.0': 'assets downloads for a tag',
-    '/github/assets-dl/electron/electron/total': 'total assets downloads for all releases',
+    '/github/assets-dl/electron/electron/total': 'total assets downloads (recent releases)',
     '/github/dependents-repo/micromatch/micromatch': 'repository dependents',
     '/github/dependents-pkg/micromatch/micromatch': 'package dependents',
     '/github/dependabot/ubuntu/yaru': 'dependabot status',
@@ -195,42 +195,22 @@ async function meta ({ owner, repo }: PathArgs): Promise<any> {
 
 async function downloads ({ owner, repo, tag }: PathArgs) {
   if (tag === 'total' || tag === 'all') {
-    const MAX_PAGES = 5
-    let page = 1
-    let totalDownloads = 0
-    let hasReleases = false
+    const releases = await restGithub(`repos/${owner}/${repo}/releases`, {
+      per_page: '30'
+    })
 
-    while (page <= MAX_PAGES) {
-      const releases: any = await restGithub(`repos/${owner}/${repo}/releases`, {
-        per_page: '100',
-        page: String(page)
-      })
-
-      if (!releases || !Array.isArray(releases) || !releases.length) {
-        break
-      }
-
-      hasReleases = true
-
-      for (const release of releases) {
-        if (release.assets && Array.isArray(release.assets)) {
-          for (const asset of release.assets) {
-            totalDownloads += asset.download_count || 0
-          }
-        }
-      }
-
-      if (releases.length < 100) break
-      page++
-    }
-
-    if (!hasReleases) {
+    if (!releases || !Array.isArray(releases) || !releases.length) {
       return {
         subject: 'downloads',
         status: 'no releases',
         color: 'grey'
       }
     }
+
+    const totalDownloads = releases.reduce((acc, release) => {
+      if (!release.assets || !release.assets.length) return acc
+      return acc + release.assets.reduce((sum: number, asset: any) => sum + (asset.download_count || 0), 0)
+    }, 0)
 
     return {
       subject: 'downloads',

--- a/pages/api/github.ts
+++ b/pages/api/github.ts
@@ -48,6 +48,7 @@ export default createBadgenHandler({
     '/github/last-commit/micromatch/micromatch/4.0.1': 'last commit (tag ref)',
     '/github/assets-dl/electron/electron': 'assets downloads for latest release',
     '/github/assets-dl/electron/electron/v7.0.0': 'assets downloads for a tag',
+    '/github/assets-dl/electron/electron/total': 'total assets downloads for all releases',
     '/github/dependents-repo/micromatch/micromatch': 'repository dependents',
     '/github/dependents-pkg/micromatch/micromatch': 'package dependents',
     '/github/dependabot/ubuntu/yaru': 'dependabot status',
@@ -193,6 +194,51 @@ async function meta ({ owner, repo }: PathArgs): Promise<any> {
 }
 
 async function downloads ({ owner, repo, tag }: PathArgs) {
+  if (tag === 'total' || tag === 'all') {
+    const MAX_PAGES = 5
+    let page = 1
+    let totalDownloads = 0
+    let hasReleases = false
+
+    while (page <= MAX_PAGES) {
+      const releases: any = await restGithub(`repos/${owner}/${repo}/releases`, {
+        per_page: '100',
+        page: String(page)
+      })
+
+      if (!releases || !Array.isArray(releases) || !releases.length) {
+        break
+      }
+
+      hasReleases = true
+
+      for (const release of releases) {
+        if (release.assets && Array.isArray(release.assets)) {
+          for (const asset of release.assets) {
+            totalDownloads += asset.download_count || 0
+          }
+        }
+      }
+
+      if (releases.length < 100) break
+      page++
+    }
+
+    if (!hasReleases) {
+      return {
+        subject: 'downloads',
+        status: 'no releases',
+        color: 'grey'
+      }
+    }
+
+    return {
+      subject: 'downloads',
+      status: millify(totalDownloads),
+      color: 'green'
+    }
+  }
+
   const releaseSelection = tag ? `tags/${tag}` : 'latest'
   const release = await restGithub(`repos/${owner}/${repo}/releases/${releaseSelection}`)
 
@@ -204,8 +250,7 @@ async function downloads ({ owner, repo, tag }: PathArgs) {
     }
   }
 
-   
-  const downloadCount = release.assets.reduce((result, { download_count }) => {
+  const downloadCount = release.assets.reduce((result: number, { download_count }: any) => {
     return result + download_count
   }, 0)
 

--- a/public/badges.md
+++ b/public/badges.md
@@ -55,6 +55,7 @@
 - [last commit (tag ref)](https://badgen.net/github/last-commit/micromatch/micromatch/4.0.1)
 - [assets downloads for latest release](https://badgen.net/github/assets-dl/electron/electron)
 - [assets downloads for a tag](https://badgen.net/github/assets-dl/electron/electron/v7.0.0)
+- [total assets downloads for all releases](https://badgen.net/github/assets-dl/electron/electron/total)
 - [repository dependents](https://badgen.net/github/dependents-repo/micromatch/micromatch)
 - [package dependents](https://badgen.net/github/dependents-pkg/micromatch/micromatch)
 - [dependabot status](https://badgen.net/github/dependabot/ubuntu/yaru)

--- a/public/badges.md
+++ b/public/badges.md
@@ -55,7 +55,7 @@
 - [last commit (tag ref)](https://badgen.net/github/last-commit/micromatch/micromatch/4.0.1)
 - [assets downloads for latest release](https://badgen.net/github/assets-dl/electron/electron)
 - [assets downloads for a tag](https://badgen.net/github/assets-dl/electron/electron/v7.0.0)
-- [total assets downloads for all releases](https://badgen.net/github/assets-dl/electron/electron/total)
+- [total assets downloads (recent releases)](https://badgen.net/github/assets-dl/electron/electron/total)
 - [repository dependents](https://badgen.net/github/dependents-repo/micromatch/micromatch)
 - [package dependents](https://badgen.net/github/dependents-pkg/micromatch/micromatch)
 - [dependabot status](https://badgen.net/github/dependabot/ubuntu/yaru)


### PR DESCRIPTION
## Problem

Currently, the GitHub assets download badge endpoint (`/github/assets-dl/:owner/:repo/:tag?`) only supports fetching downloads for the latest release (when tag is omitted) or for a specific release tag (e.g. `/v7.0.0`).

Users who want to display the total asset download count across recent releases cannot do so.

## Solution

Add support for `/github/assets-dl/:owner/:repo/total` (and `/all`) to calculate total asset downloads for recent releases.

- Queries `GET /repos/{owner}/{repo}/releases?per_page=30`.
- Sums `download_count` for all assets found across the returned releases.
- Formats the sum using `millify()` and returns a green badge (or grey `'no releases'` if none exist).
- Updates documentation and example lists in `pages/api/github.ts` and `public/badges.md`.

## Implementation Notes & Trade-offs

1. **Not 100% of All-Time Downloads for Mega Repos:** This solution does not sum 100% of releases for mega repositories with hundreds of releases.
2. **Timeout Constraints:** While increasing `per_page` to `100` fetches more releases, heavy repositories with many binary assets per release (like `electron/electron`) generate large JSON responses that trigger `RequestError: Timeout awaiting 'request' for 6400ms` configured in `libs/got.ts`.
3. **Pagination Risks:** Implementing a full pagination loop to iterate through all release pages until the end was considered, but poses a risk of hitting rate limits and creating excessive request bursts (DDoS-like behavior) on very large repositories.
4. **Current Choice (`per_page=30`):** Querying the 30 most recent releases proved to be the safest and most reliable threshold during testing across various repositories.

> Suggestions for improvements or alternative strategies are welcome!

## Usage

```md
![Total Downloads](https://badgen.net/github/assets-dl/electron/electron/total)
```

<img width="823" height="452" alt="Screenshot 2026-07-22 at 20 30 07" src="https://github.com/user-attachments/assets/633e8fc5-8d56-4ab0-8aee-190edee65413" />
